### PR TITLE
Allow to connect to LDAP server by URI string

### DIFF
--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -15,7 +15,32 @@ namespace LdapForNet
         private SafeHandle _ld;
         private bool _bound;
 
-        public void Connect(string hostname, int port = (int) Native.Native.LdapPort.LDAP,
+		public void Connect(Uri uri,
+			Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
+		{
+			var details = new Dictionary<string, string>
+			{
+				[nameof(uri)] = uri.ToString(),
+				[nameof(version)] = version.ToString()
+			};
+			var nativeHandle = IntPtr.Zero;
+
+			_native.ThrowIfError(
+				_native.Init(ref nativeHandle, uri),
+				nameof(_native.Init),
+				details
+			);
+			_ld = new LdapHandle(nativeHandle);
+			var ldapVersion = (int)version;
+
+			_native.ThrowIfError(
+				_native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
+				nameof(_native.ldap_set_option),
+				details
+			);
+		}
+
+		public void Connect(string hostname, int port = (int) Native.Native.LdapPort.LDAP,
             Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
         {
             var details = new Dictionary<string, string>

--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -9,38 +9,38 @@ using LdapForNet.RequestHandlers;
 
 namespace LdapForNet
 {
-    public class LdapConnection:ILdapConnection
+    public class LdapConnection : ILdapConnection
     {
         private readonly LdapNative _native = LdapNative.Instance;
         private SafeHandle _ld;
         private bool _bound;
 
-		public void Connect(Uri uri,
-			Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
-		{
-			var details = new Dictionary<string, string>
-			{
-				[nameof(uri)] = uri.ToString(),
-				[nameof(version)] = version.ToString()
-			};
-			var nativeHandle = IntPtr.Zero;
+        public void Connect(Uri uri,
+            Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
+        {
+            var details = new Dictionary<string, string>
+            {
+                [nameof(uri)] = uri.ToString(),
+                [nameof(version)] = version.ToString()
+            };
+            var nativeHandle = IntPtr.Zero;
 
-			_native.ThrowIfError(
-				_native.Init(ref nativeHandle, uri),
-				nameof(_native.Init),
-				details
-			);
-			_ld = new LdapHandle(nativeHandle);
-			var ldapVersion = (int)version;
+            _native.ThrowIfError(
+                _native.Init(ref nativeHandle, uri),
+                nameof(_native.Init),
+                details
+            );
+            _ld = new LdapHandle(nativeHandle);
+            var ldapVersion = (int)version;
 
-			_native.ThrowIfError(
-				_native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
-				nameof(_native.ldap_set_option),
-				details
-			);
-		}
+            _native.ThrowIfError(
+                _native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
+                nameof(_native.ldap_set_option),
+                details
+            );
+        }
 
-		public void Connect(string hostname, int port = (int) Native.Native.LdapPort.LDAP,
+        public void Connect(string hostname, int port = (int)Native.Native.LdapPort.LDAP,
             Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
         {
             var details = new Dictionary<string, string>
@@ -56,10 +56,10 @@ namespace LdapForNet
                 details
             );
             _ld = new LdapHandle(nativeHandle);
-            var ldapVersion = (int) version;
+            var ldapVersion = (int)version;
 
             _native.ThrowIfError(
-                _native.ldap_set_option(_ld, (int) Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
+                _native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
                 nameof(_native.ldap_set_option),
                 details
             );
@@ -116,28 +116,28 @@ namespace LdapForNet
         public void SetOption(Native.Native.LdapOption option, int value)
         {
             ThrowIfNotBound();
-            _native.ThrowIfError(_native.ldap_set_option(_ld, (int) option, ref value),
+            _native.ThrowIfError(_native.ldap_set_option(_ld, (int)option, ref value),
                 nameof(_native.ldap_set_option));
         }
 
         public void SetOption(Native.Native.LdapOption option, string value)
         {
             ThrowIfNotBound();
-            _native.ThrowIfError(_native.ldap_set_option(_ld, (int) option, ref value),
+            _native.ThrowIfError(_native.ldap_set_option(_ld, (int)option, ref value),
                 nameof(_native.ldap_set_option));
         }
 
         public void SetOption(Native.Native.LdapOption option, IntPtr valuePtr)
         {
             ThrowIfNotBound();
-            _native.ThrowIfError(_native.ldap_set_option(_ld, (int) option, valuePtr), nameof(_native.ldap_set_option));
+            _native.ThrowIfError(_native.ldap_set_option(_ld, (int)option, valuePtr), nameof(_native.ldap_set_option));
         }
 
         public IList<LdapEntry> Search(string @base, string filter,
             Native.Native.LdapSearchScope scope = Native.Native.LdapSearchScope.LDAP_SCOPE_SUBTREE)
         {
-            var response = (SearchResponse) SendRequest(new SearchRequest(@base, filter, scope));
-            if(response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
+            var response = (SearchResponse)SendRequest(new SearchRequest(@base, filter, scope));
+            if (response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
             {
                 ThrowIfResponseError(response);
             }
@@ -148,14 +148,14 @@ namespace LdapForNet
             Native.Native.LdapSearchScope scope = Native.Native.LdapSearchScope.LDAP_SCOPE_SUBTREE,
             CancellationToken token = default)
         {
-            var response = (SearchResponse) await SendRequestAsync(new SearchRequest(@base, filter, scope), token);
-            if(response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
+            var response = (SearchResponse)await SendRequestAsync(new SearchRequest(@base, filter, scope), token);
+            if (response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
             {
                 ThrowIfResponseError(response);
             }
             return response.Entries;
         }
-        
+
         public void Add(LdapEntry entry) => ThrowIfResponseError(SendRequest(new AddRequest(entry)));
 
         public async Task<DirectoryResponse> SendRequestAsync(DirectoryRequest directoryRequest,
@@ -183,7 +183,7 @@ namespace LdapForNet
         }
 
 
-        public async Task ModifyAsync(LdapModifyEntry entry, CancellationToken token = default) => 
+        public async Task ModifyAsync(LdapModifyEntry entry, CancellationToken token = default) =>
             ThrowIfResponseError(await SendRequestAsync(new ModifyRequest(entry), token));
 
         public void Modify(LdapModifyEntry entry) => ThrowIfResponseError(SendRequest(new ModifyRequest(entry)));
@@ -207,11 +207,11 @@ namespace LdapForNet
 
         public async Task RenameAsync(string dn, string newRdn, string newParent, bool isDeleteOldRdn,
             CancellationToken cancellationToken = default) =>
-            ThrowIfResponseError(await SendRequestAsync(new ModifyDNRequest(dn, newParent, newRdn) {DeleteOldRdn = isDeleteOldRdn},
+            ThrowIfResponseError(await SendRequestAsync(new ModifyDNRequest(dn, newParent, newRdn) { DeleteOldRdn = isDeleteOldRdn },
                 cancellationToken));
 
         public void Rename(string dn, string newRdn, string newParent, bool isDeleteOldRdn) =>
-            ThrowIfResponseError(SendRequest(new ModifyDNRequest(dn, newParent, newRdn) {DeleteOldRdn = isDeleteOldRdn}));
+            ThrowIfResponseError(SendRequest(new ModifyDNRequest(dn, newParent, newRdn) { DeleteOldRdn = isDeleteOldRdn }));
 
         public async Task AddAsync(LdapEntry entry, CancellationToken token = default) =>
             ThrowIfResponseError(await SendRequestAsync(new AddRequest(entry), token));
@@ -236,11 +236,11 @@ namespace LdapForNet
                 {
                     throw new LdapException($"Unknown search type {resType}", nameof(_native.ldap_result), 1);
                 }
-                
+
                 if (status == LdapResultCompleteStatus.Complete)
                 {
                     var res = ParseResultError(msg, out var errorMessage, out _);
-                    response.ResultCode = (Native.Native.ResultCode) res;
+                    response.ResultCode = (Native.Native.ResultCode)res;
                     response.ErrorMessage = errorMessage;
                 }
             }
@@ -302,7 +302,7 @@ namespace LdapForNet
                 [nameof(matchedMessage)] = matchedMessage
             });
         }
-        
+
         private int ParseResultError(IntPtr msg, out string errorMessage, out string matchedMessage)
         {
             var matchedMessagePtr = IntPtr.Zero;
@@ -314,7 +314,7 @@ namespace LdapForNet
                 ref referrals, ref serverctrls, 1), nameof(_native.ldap_parse_result));
             errorMessage = Marshal.PtrToStringAnsi(errorMessagePtr);
             matchedMessage = Marshal.PtrToStringAnsi(matchedMessagePtr);
-            
+
             return res;
         }
 
@@ -353,10 +353,10 @@ namespace LdapForNet
                 throw new LdapException($"Not bound. Please invoke {nameof(Bind)} method before.");
             }
         }
-        
+
         private void ThrowIfResponseError(DirectoryResponse response)
         {
-            _native.ThrowIfError(_ld, (int) response.ResultCode, nameof(_native.ldap_parse_result),
+            _native.ThrowIfError(_ld, (int)response.ResultCode, nameof(_native.ldap_parse_result),
                 new Dictionary<string, string>
                 {
                     [nameof(response.ErrorMessage)] = response.ErrorMessage,

--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -15,32 +15,32 @@ namespace LdapForNet
         private SafeHandle _ld;
         private bool _bound;
 
-		public void Connect(Uri uri,
-			Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
-		{
-			var details = new Dictionary<string, string>
-			{
-				[nameof(uri)] = uri.ToString(),
-				[nameof(version)] = version.ToString()
-			};
-			var nativeHandle = IntPtr.Zero;
+        public void Connect(Uri uri,
+            Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
+        {
+            var details = new Dictionary<string, string>
+            {
+                [nameof(uri)] = uri.ToString(),
+                [nameof(version)] = version.ToString()
+            };
+            var nativeHandle = IntPtr.Zero;
 
-			_native.ThrowIfError(
-				_native.Init(ref nativeHandle, uri),
-				nameof(_native.Init),
-				details
-			);
-			_ld = new LdapHandle(nativeHandle);
-			var ldapVersion = (int)version;
+            _native.ThrowIfError(
+                _native.Init(ref nativeHandle, uri),
+                nameof(_native.Init),
+                details
+            );
+            _ld = new LdapHandle(nativeHandle);
+            var ldapVersion = (int)version;
 
-			_native.ThrowIfError(
-				_native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
-				nameof(_native.ldap_set_option),
-				details
-			);
-		}
+            _native.ThrowIfError(
+                _native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
+                nameof(_native.ldap_set_option),
+                details
+            );
+        }
 
-		public void Connect(string hostname, int port = (int) Native.Native.LdapPort.LDAP,
+        public void Connect(string hostname, int port = (int) Native.Native.LdapPort.LDAP,
             Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
         {
             var details = new Dictionary<string, string>

--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -9,38 +9,38 @@ using LdapForNet.RequestHandlers;
 
 namespace LdapForNet
 {
-    public class LdapConnection : ILdapConnection
+    public class LdapConnection:ILdapConnection
     {
         private readonly LdapNative _native = LdapNative.Instance;
         private SafeHandle _ld;
         private bool _bound;
 
-        public void Connect(Uri uri,
-            Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
-        {
-            var details = new Dictionary<string, string>
-            {
-                [nameof(uri)] = uri.ToString(),
-                [nameof(version)] = version.ToString()
-            };
-            var nativeHandle = IntPtr.Zero;
+		public void Connect(Uri uri,
+			Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
+		{
+			var details = new Dictionary<string, string>
+			{
+				[nameof(uri)] = uri.ToString(),
+				[nameof(version)] = version.ToString()
+			};
+			var nativeHandle = IntPtr.Zero;
 
-            _native.ThrowIfError(
-                _native.Init(ref nativeHandle, uri),
-                nameof(_native.Init),
-                details
-            );
-            _ld = new LdapHandle(nativeHandle);
-            var ldapVersion = (int)version;
+			_native.ThrowIfError(
+				_native.Init(ref nativeHandle, uri),
+				nameof(_native.Init),
+				details
+			);
+			_ld = new LdapHandle(nativeHandle);
+			var ldapVersion = (int)version;
 
-            _native.ThrowIfError(
-                _native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
-                nameof(_native.ldap_set_option),
-                details
-            );
-        }
+			_native.ThrowIfError(
+				_native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
+				nameof(_native.ldap_set_option),
+				details
+			);
+		}
 
-        public void Connect(string hostname, int port = (int)Native.Native.LdapPort.LDAP,
+		public void Connect(string hostname, int port = (int) Native.Native.LdapPort.LDAP,
             Native.Native.LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3)
         {
             var details = new Dictionary<string, string>
@@ -56,10 +56,10 @@ namespace LdapForNet
                 details
             );
             _ld = new LdapHandle(nativeHandle);
-            var ldapVersion = (int)version;
+            var ldapVersion = (int) version;
 
             _native.ThrowIfError(
-                _native.ldap_set_option(_ld, (int)Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
+                _native.ldap_set_option(_ld, (int) Native.Native.LdapOption.LDAP_OPT_PROTOCOL_VERSION, ref ldapVersion),
                 nameof(_native.ldap_set_option),
                 details
             );
@@ -116,28 +116,28 @@ namespace LdapForNet
         public void SetOption(Native.Native.LdapOption option, int value)
         {
             ThrowIfNotBound();
-            _native.ThrowIfError(_native.ldap_set_option(_ld, (int)option, ref value),
+            _native.ThrowIfError(_native.ldap_set_option(_ld, (int) option, ref value),
                 nameof(_native.ldap_set_option));
         }
 
         public void SetOption(Native.Native.LdapOption option, string value)
         {
             ThrowIfNotBound();
-            _native.ThrowIfError(_native.ldap_set_option(_ld, (int)option, ref value),
+            _native.ThrowIfError(_native.ldap_set_option(_ld, (int) option, ref value),
                 nameof(_native.ldap_set_option));
         }
 
         public void SetOption(Native.Native.LdapOption option, IntPtr valuePtr)
         {
             ThrowIfNotBound();
-            _native.ThrowIfError(_native.ldap_set_option(_ld, (int)option, valuePtr), nameof(_native.ldap_set_option));
+            _native.ThrowIfError(_native.ldap_set_option(_ld, (int) option, valuePtr), nameof(_native.ldap_set_option));
         }
 
         public IList<LdapEntry> Search(string @base, string filter,
             Native.Native.LdapSearchScope scope = Native.Native.LdapSearchScope.LDAP_SCOPE_SUBTREE)
         {
-            var response = (SearchResponse)SendRequest(new SearchRequest(@base, filter, scope));
-            if (response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
+            var response = (SearchResponse) SendRequest(new SearchRequest(@base, filter, scope));
+            if(response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
             {
                 ThrowIfResponseError(response);
             }
@@ -148,14 +148,14 @@ namespace LdapForNet
             Native.Native.LdapSearchScope scope = Native.Native.LdapSearchScope.LDAP_SCOPE_SUBTREE,
             CancellationToken token = default)
         {
-            var response = (SearchResponse)await SendRequestAsync(new SearchRequest(@base, filter, scope), token);
-            if (response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
+            var response = (SearchResponse) await SendRequestAsync(new SearchRequest(@base, filter, scope), token);
+            if(response.ResultCode != Native.Native.ResultCode.Success && !response.Entries.Any())
             {
                 ThrowIfResponseError(response);
             }
             return response.Entries;
         }
-
+        
         public void Add(LdapEntry entry) => ThrowIfResponseError(SendRequest(new AddRequest(entry)));
 
         public async Task<DirectoryResponse> SendRequestAsync(DirectoryRequest directoryRequest,
@@ -183,7 +183,7 @@ namespace LdapForNet
         }
 
 
-        public async Task ModifyAsync(LdapModifyEntry entry, CancellationToken token = default) =>
+        public async Task ModifyAsync(LdapModifyEntry entry, CancellationToken token = default) => 
             ThrowIfResponseError(await SendRequestAsync(new ModifyRequest(entry), token));
 
         public void Modify(LdapModifyEntry entry) => ThrowIfResponseError(SendRequest(new ModifyRequest(entry)));
@@ -207,11 +207,11 @@ namespace LdapForNet
 
         public async Task RenameAsync(string dn, string newRdn, string newParent, bool isDeleteOldRdn,
             CancellationToken cancellationToken = default) =>
-            ThrowIfResponseError(await SendRequestAsync(new ModifyDNRequest(dn, newParent, newRdn) { DeleteOldRdn = isDeleteOldRdn },
+            ThrowIfResponseError(await SendRequestAsync(new ModifyDNRequest(dn, newParent, newRdn) {DeleteOldRdn = isDeleteOldRdn},
                 cancellationToken));
 
         public void Rename(string dn, string newRdn, string newParent, bool isDeleteOldRdn) =>
-            ThrowIfResponseError(SendRequest(new ModifyDNRequest(dn, newParent, newRdn) { DeleteOldRdn = isDeleteOldRdn }));
+            ThrowIfResponseError(SendRequest(new ModifyDNRequest(dn, newParent, newRdn) {DeleteOldRdn = isDeleteOldRdn}));
 
         public async Task AddAsync(LdapEntry entry, CancellationToken token = default) =>
             ThrowIfResponseError(await SendRequestAsync(new AddRequest(entry), token));
@@ -236,11 +236,11 @@ namespace LdapForNet
                 {
                     throw new LdapException($"Unknown search type {resType}", nameof(_native.ldap_result), 1);
                 }
-
+                
                 if (status == LdapResultCompleteStatus.Complete)
                 {
                     var res = ParseResultError(msg, out var errorMessage, out _);
-                    response.ResultCode = (Native.Native.ResultCode)res;
+                    response.ResultCode = (Native.Native.ResultCode) res;
                     response.ErrorMessage = errorMessage;
                 }
             }
@@ -302,7 +302,7 @@ namespace LdapForNet
                 [nameof(matchedMessage)] = matchedMessage
             });
         }
-
+        
         private int ParseResultError(IntPtr msg, out string errorMessage, out string matchedMessage)
         {
             var matchedMessagePtr = IntPtr.Zero;
@@ -314,7 +314,7 @@ namespace LdapForNet
                 ref referrals, ref serverctrls, 1), nameof(_native.ldap_parse_result));
             errorMessage = Marshal.PtrToStringAnsi(errorMessagePtr);
             matchedMessage = Marshal.PtrToStringAnsi(matchedMessagePtr);
-
+            
             return res;
         }
 
@@ -353,10 +353,10 @@ namespace LdapForNet
                 throw new LdapException($"Not bound. Please invoke {nameof(Bind)} method before.");
             }
         }
-
+        
         private void ThrowIfResponseError(DirectoryResponse response)
         {
-            _native.ThrowIfError(_ld, (int)response.ResultCode, nameof(_native.ldap_parse_result),
+            _native.ThrowIfError(_ld, (int) response.ResultCode, nameof(_native.ldap_parse_result),
                 new Dictionary<string, string>
                 {
                     [nameof(response.ErrorMessage)] = response.ErrorMessage,

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -29,12 +29,12 @@ namespace LdapForNet.Native
             throw new PlatformNotSupportedException();
         }
 
-        internal abstract int Init(ref IntPtr ld, Uri uri);
-        internal abstract int Init(ref IntPtr ld, string hostname, int port);
+		internal abstract int Init(ref IntPtr ld, Uri uri);
+		internal abstract int Init(ref IntPtr ld, string hostname, int port);
         internal abstract int BindKerberos(SafeHandle ld);
         internal abstract Task<IntPtr> BindKerberosAsync(SafeHandle ld);
-        internal abstract int BindSimple(SafeHandle ld, string who, string password);
-        internal abstract Task<IntPtr> BindSimpleAsync(SafeHandle ld, string who, string password);
+        internal abstract int BindSimple(SafeHandle ld, string who,string password);
+        internal abstract Task<IntPtr> BindSimpleAsync(SafeHandle ld, string who,string password);
         internal abstract int ldap_set_option(SafeHandle ld, int option, ref int invalue);
         internal abstract int ldap_set_option(SafeHandle ld, int option, ref string invalue);
         internal abstract int ldap_set_option(SafeHandle ld, int option, IntPtr invalue);
@@ -43,8 +43,8 @@ namespace LdapForNet.Native
         internal abstract int ldap_unbind_s(IntPtr ld);
         internal abstract int ldap_search_ext(SafeHandle ld, string @base, int scope, string filter, string[] attrs,
             int attrsonly, IntPtr serverctrls, IntPtr clientctrls, IntPtr timeout, int sizelimit, ref int msgidp);
-        internal abstract LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage);
-        internal abstract int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp, ref IntPtr referralsp, ref IntPtr serverctrlsp, int freeit);
+        internal abstract LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout,ref IntPtr pMessage);
+        internal abstract int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp, ref IntPtr referralsp,ref IntPtr serverctrlsp, int freeit);
         internal abstract string LdapError2String(int error);
         internal abstract string GetAdditionalErrorInfo(SafeHandle ld);
         internal abstract int ldap_parse_reference(SafeHandle ld, IntPtr reference, ref string[] referralsp, ref IntPtr serverctrlsp, int freeit);
@@ -57,18 +57,18 @@ namespace LdapForNet.Native
         internal abstract IntPtr ldap_next_attribute(SafeHandle ld, IntPtr entry, IntPtr pBer);
         internal abstract void ldap_value_free(IntPtr vals);
         internal abstract IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer);
-        internal abstract int ldap_add_ext(SafeHandle ld, string dn, IntPtr attrs, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
-        internal abstract int ldap_modify_ext(SafeHandle ld, string dn, IntPtr mods, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
+        internal abstract int ldap_add_ext(SafeHandle ld,string dn,IntPtr attrs,IntPtr serverctrls, IntPtr clientctrls,ref int msgidp );
+        internal abstract int ldap_modify_ext(SafeHandle ld, string dn,IntPtr mods , IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int ldap_delete_ext(SafeHandle ld, string dn, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int Compare(SafeHandle ld, string dn, string attr, string value, IntPtr bvalue, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int ldap_rename(SafeHandle ld, string dn, string newrdn, string newparent, int deleteoldrdn, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
-        internal abstract int ldap_extended_operation(SafeHandle ld, string requestoid, IntPtr requestdata, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
+        internal abstract int ldap_extended_operation(SafeHandle ld,string requestoid,IntPtr requestdata,IntPtr serverctrls, IntPtr clientctrls,ref int msgidp );
         internal abstract int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt);
 
         internal abstract void ldap_controls_free(IntPtr ctrls);
-
-
-        internal void ThrowIfError(int res, string method, IDictionary<string, string> details = default)
+        
+        
+        internal void ThrowIfError(int res, string method, IDictionary<string,string> details = default)
         {
             if (res != (int)ResultCode.Success)
             {
@@ -80,18 +80,18 @@ namespace LdapForNet.Native
             }
         }
 
-        private static string DetailsToString(IDictionary<string, string> details)
+        private static string DetailsToString(IDictionary<string,string> details)
         {
             return string.Join(Environment.NewLine, details.Select(_ => $"{_.Key}:{_.Value}"));
         }
 
-        internal void ThrowIfError(SafeHandle ld, int res, string method, IDictionary<string, string> details = default)
+        internal void ThrowIfError(SafeHandle ld, int res, string method, IDictionary<string,string> details = default)
         {
             if (res != (int)ResultCode.Success)
             {
                 var error = LdapError2String(res);
                 var info = GetAdditionalErrorInfo(ld);
-                var message = !string.IsNullOrWhiteSpace(info) ? $"{error}. {info}" : error;
+                var message = !string.IsNullOrWhiteSpace(info)? $"{error}. {info}": error;
                 if (details != default)
                 {
                     throw new LdapException(message, method, res, DetailsToString(details));

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -28,8 +28,9 @@ namespace LdapForNet.Native
             }
             throw new PlatformNotSupportedException();
         }
-        
-        internal abstract int Init(ref IntPtr ld, string hostname, int port);
+
+		internal abstract int Init(ref IntPtr ld, Uri uri);
+		internal abstract int Init(ref IntPtr ld, string hostname, int port);
         internal abstract int BindKerberos(SafeHandle ld);
         internal abstract Task<IntPtr> BindKerberosAsync(SafeHandle ld);
         internal abstract int BindSimple(SafeHandle ld, string who,string password);

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -29,12 +29,12 @@ namespace LdapForNet.Native
             throw new PlatformNotSupportedException();
         }
 
-		internal abstract int Init(ref IntPtr ld, Uri uri);
-		internal abstract int Init(ref IntPtr ld, string hostname, int port);
+        internal abstract int Init(ref IntPtr ld, Uri uri);
+        internal abstract int Init(ref IntPtr ld, string hostname, int port);
         internal abstract int BindKerberos(SafeHandle ld);
         internal abstract Task<IntPtr> BindKerberosAsync(SafeHandle ld);
-        internal abstract int BindSimple(SafeHandle ld, string who,string password);
-        internal abstract Task<IntPtr> BindSimpleAsync(SafeHandle ld, string who,string password);
+        internal abstract int BindSimple(SafeHandle ld, string who, string password);
+        internal abstract Task<IntPtr> BindSimpleAsync(SafeHandle ld, string who, string password);
         internal abstract int ldap_set_option(SafeHandle ld, int option, ref int invalue);
         internal abstract int ldap_set_option(SafeHandle ld, int option, ref string invalue);
         internal abstract int ldap_set_option(SafeHandle ld, int option, IntPtr invalue);
@@ -43,8 +43,8 @@ namespace LdapForNet.Native
         internal abstract int ldap_unbind_s(IntPtr ld);
         internal abstract int ldap_search_ext(SafeHandle ld, string @base, int scope, string filter, string[] attrs,
             int attrsonly, IntPtr serverctrls, IntPtr clientctrls, IntPtr timeout, int sizelimit, ref int msgidp);
-        internal abstract LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout,ref IntPtr pMessage);
-        internal abstract int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp, ref IntPtr referralsp,ref IntPtr serverctrlsp, int freeit);
+        internal abstract LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage);
+        internal abstract int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp, ref IntPtr referralsp, ref IntPtr serverctrlsp, int freeit);
         internal abstract string LdapError2String(int error);
         internal abstract string GetAdditionalErrorInfo(SafeHandle ld);
         internal abstract int ldap_parse_reference(SafeHandle ld, IntPtr reference, ref string[] referralsp, ref IntPtr serverctrlsp, int freeit);
@@ -57,18 +57,18 @@ namespace LdapForNet.Native
         internal abstract IntPtr ldap_next_attribute(SafeHandle ld, IntPtr entry, IntPtr pBer);
         internal abstract void ldap_value_free(IntPtr vals);
         internal abstract IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer);
-        internal abstract int ldap_add_ext(SafeHandle ld,string dn,IntPtr attrs,IntPtr serverctrls, IntPtr clientctrls,ref int msgidp );
-        internal abstract int ldap_modify_ext(SafeHandle ld, string dn,IntPtr mods , IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
+        internal abstract int ldap_add_ext(SafeHandle ld, string dn, IntPtr attrs, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
+        internal abstract int ldap_modify_ext(SafeHandle ld, string dn, IntPtr mods, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int ldap_delete_ext(SafeHandle ld, string dn, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int Compare(SafeHandle ld, string dn, string attr, string value, IntPtr bvalue, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int ldap_rename(SafeHandle ld, string dn, string newrdn, string newparent, int deleteoldrdn, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
-        internal abstract int ldap_extended_operation(SafeHandle ld,string requestoid,IntPtr requestdata,IntPtr serverctrls, IntPtr clientctrls,ref int msgidp );
+        internal abstract int ldap_extended_operation(SafeHandle ld, string requestoid, IntPtr requestdata, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt);
 
         internal abstract void ldap_controls_free(IntPtr ctrls);
-        
-        
-        internal void ThrowIfError(int res, string method, IDictionary<string,string> details = default)
+
+
+        internal void ThrowIfError(int res, string method, IDictionary<string, string> details = default)
         {
             if (res != (int)ResultCode.Success)
             {
@@ -80,18 +80,18 @@ namespace LdapForNet.Native
             }
         }
 
-        private static string DetailsToString(IDictionary<string,string> details)
+        private static string DetailsToString(IDictionary<string, string> details)
         {
             return string.Join(Environment.NewLine, details.Select(_ => $"{_.Key}:{_.Value}"));
         }
 
-        internal void ThrowIfError(SafeHandle ld, int res, string method, IDictionary<string,string> details = default)
+        internal void ThrowIfError(SafeHandle ld, int res, string method, IDictionary<string, string> details = default)
         {
             if (res != (int)ResultCode.Success)
             {
                 var error = LdapError2String(res);
                 var info = GetAdditionalErrorInfo(ld);
-                var message = !string.IsNullOrWhiteSpace(info)? $"{error}. {info}": error;
+                var message = !string.IsNullOrWhiteSpace(info) ? $"{error}. {info}" : error;
                 if (details != default)
                 {
                     throw new LdapException(message, method, res, DetailsToString(details));

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -29,8 +29,8 @@ namespace LdapForNet.Native
             throw new PlatformNotSupportedException();
         }
 
-		internal abstract int Init(ref IntPtr ld, Uri uri);
-		internal abstract int Init(ref IntPtr ld, string hostname, int port);
+        internal abstract int Init(ref IntPtr ld, Uri uri);
+        internal abstract int Init(ref IntPtr ld, string hostname, int port);
         internal abstract int BindKerberos(SafeHandle ld);
         internal abstract Task<IntPtr> BindKerberosAsync(SafeHandle ld);
         internal abstract int BindSimple(SafeHandle ld, string who,string password);

--- a/LdapForNet/Native/LdapNativeLinux.cs
+++ b/LdapForNet/Native/LdapNativeLinux.cs
@@ -5,13 +5,13 @@ using System.Threading.Tasks;
 
 namespace LdapForNet.Native
 {
-    internal class LdapNativeLinux:LdapNative
+    internal class LdapNativeLinux : LdapNative
     {
-		internal override int Init(ref IntPtr ld, Uri uri) =>
-			NativeMethodsLinux.ldap_initialize(ref ld, uri.ToString());
+        internal override int Init(ref IntPtr ld, Uri uri) =>
+            NativeMethodsLinux.ldap_initialize(ref ld, uri.ToString());
 
-		internal override int Init(ref IntPtr ld, string hostname, int port) => 
-            NativeMethodsLinux.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
+        internal override int Init(ref IntPtr ld, string hostname, int port) =>
+            NativeMethodsLinux.ldap_initialize(ref ld, $"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)
         {
@@ -22,13 +22,13 @@ namespace LdapForNet.Native
             return NativeMethodsLinux.ldap_sasl_interactive_bind_s(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
                 (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET, (l, flags, d, interact) => (int)Native.ResultCode.Success, ptr);
         }
-        
+
         private Native.LdapSaslDefaults GetSaslDefaults(SafeHandle ld)
         {
             var defaults = new Native.LdapSaslDefaults { mech = Native.LdapAuthMechanism.GSSAPI };
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm),nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid),nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid),nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm), nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid), nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid), nameof(ldap_get_option));
             return defaults;
         }
 
@@ -47,10 +47,10 @@ namespace LdapForNet.Native
                 do
                 {
                     rc = NativeMethodsLinux.ldap_sasl_interactive_bind(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
-                        (uint) Native.LdapInteractionFlags.LDAP_SASL_QUIET,
-                        SaslInteractProc , ptr, result, ref rmech,
+                        (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET,
+                        SaslInteractProc, ptr, result, ref rmech,
                         ref msgid);
-                    if (rc != (int) Native.ResultCode.SaslBindInProgress)
+                    if (rc != (int)Native.ResultCode.SaslBindInProgress)
                     {
                         break;
                     }
@@ -58,17 +58,17 @@ namespace LdapForNet.Native
 
                     if (ldap_result(ld, msgid, 0, IntPtr.Zero, ref result) == Native.LdapResultType.LDAP_ERROR)
                     {
-                        ThrowIfError(rc,nameof(NativeMethodsLinux.ldap_sasl_interactive_bind));
+                        ThrowIfError(rc, nameof(NativeMethodsLinux.ldap_sasl_interactive_bind));
                     }
 
                     if (result == IntPtr.Zero)
                     {
                         throw new LdapException("Result is not initialized", nameof(NativeMethodsLinux.ldap_sasl_interactive_bind), 1);
                     }
-                    
-                } while (rc == (int) Native.ResultCode.SaslBindInProgress);
-                
-                ThrowIfError(ld,rc, nameof(NativeMethodsLinux.ldap_sasl_interactive_bind), new Dictionary<string, string>
+
+                } while (rc == (int)Native.ResultCode.SaslBindInProgress);
+
+                ThrowIfError(ld, rc, nameof(NativeMethodsLinux.ldap_sasl_interactive_bind), new Dictionary<string, string>
                 {
                     [nameof(saslDefaults)] = saslDefaults.ToString()
                 });
@@ -76,8 +76,8 @@ namespace LdapForNet.Native
             });
             return await task.ConfigureAwait(false);
         }
-        
-        
+
+
         private static int SaslInteractProc(IntPtr ld, uint flags, IntPtr d, IntPtr @in)
         {
             var ptr = @in;
@@ -92,7 +92,7 @@ namespace LdapForNet.Native
             while (interact.id != (int)Native.SaslCb.SASL_CB_LIST_END)
             {
                 var rc = SaslInteraction(flags, interact, defaults);
-                if (rc != (int) Native.ResultCode.Success)
+                if (rc != (int)Native.ResultCode.Success)
                 {
                     return rc;
                 }
@@ -101,7 +101,7 @@ namespace LdapForNet.Native
                 interact = Marshal.PtrToStructure<Native.SaslInteract>(ptr);
             }
 
-            return (int) Native.ResultCode.Success;
+            return (int)Native.ResultCode.Success;
         }
 
         private static int SaslInteraction(uint flags, Native.SaslInteract interact, Native.LdapSaslDefaults defaults)
@@ -143,13 +143,13 @@ namespace LdapForNet.Native
             if (flags != (uint)Native.LdapInteractionFlags.LDAP_SASL_INTERACTIVE && (interact.id == (int)Native.SaslCb.SASL_CB_USER || !string.IsNullOrEmpty(interact.defresult)))
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null?(ushort)interact.defresult.Length:(ushort)0;
-                return (int) Native.ResultCode.Success;
+                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
+                return (int)Native.ResultCode.Success;
             }
 
-            if (flags == (int) Native.LdapInteractionFlags.LDAP_SASL_QUIET)
+            if (flags == (int)Native.LdapInteractionFlags.LDAP_SASL_QUIET)
             {
-                return (int) Native.ResultCode.Other;
+                return (int)Native.ResultCode.Other;
             }
 
             if (noecho)
@@ -171,10 +171,10 @@ namespace LdapForNet.Native
             else
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null ? (ushort) interact.defresult.Length : (ushort)0;
+                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
             }
 
-            return (int) Native.ResultCode.Success;
+            return (int)Native.ResultCode.Success;
         }
 
 
@@ -183,7 +183,7 @@ namespace LdapForNet.Native
 
         internal override async Task<IntPtr> BindSimpleAsync(SafeHandle _ld, string userDn, string password)
         {
-            
+
             return await Task.Factory.StartNew(() =>
             {
                 var berval = new Native.berval
@@ -192,42 +192,42 @@ namespace LdapForNet.Native
                     bv_val = Marshal.StringToHGlobalAnsi(password)
                 };
                 var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(berval));
-                Marshal.StructureToPtr(berval,ptr,false);
+                Marshal.StructureToPtr(berval, ptr, false);
                 var msgidp = 0;
                 var result = IntPtr.Zero;
                 NativeMethodsLinux.ldap_sasl_bind(_ld, userDn, null, ptr, IntPtr.Zero, IntPtr.Zero, ref msgidp);
                 if (msgidp == -1)
                 {
-                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsLinux.ldap_sasl_bind)} returns wrong or empty result",  nameof(NativeMethodsLinux.ldap_sasl_bind), 1);
+                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsLinux.ldap_sasl_bind)} returns wrong or empty result", nameof(NativeMethodsLinux.ldap_sasl_bind), 1);
                 }
 
                 var rc = ldap_result(_ld, msgidp, 0, IntPtr.Zero, ref result);
 
                 if (rc == Native.LdapResultType.LDAP_ERROR || rc == Native.LdapResultType.LDAP_TIMEOUT)
                 {
-                    ThrowIfError((int)rc,nameof(NativeMethodsLinux.ldap_sasl_bind));
+                    ThrowIfError((int)rc, nameof(NativeMethodsLinux.ldap_sasl_bind));
                 }
 
                 return result;
             }).ConfigureAwait(false);
         }
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue) 
+        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue)
             => NativeMethodsLinux.ldap_set_option(ld, option, ref invalue);
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue)=>
+        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue) =>
             NativeMethodsLinux.ldap_set_option(ld, option, ref invalue);
 
         internal override int ldap_set_option(SafeHandle ld, int option, IntPtr invalue)
-            => NativeMethodsLinux.ldap_set_option(ld, option,  invalue);
+            => NativeMethodsLinux.ldap_set_option(ld, option, invalue);
 
 
-        internal override int ldap_get_option(SafeHandle ld, int option, ref string value) 
+        internal override int ldap_get_option(SafeHandle ld, int option, ref string value)
             => NativeMethodsLinux.ldap_get_option(ld, option, ref value);
 
         internal override int ldap_get_option(SafeHandle ld, int option, ref IntPtr value)
             => NativeMethodsLinux.ldap_get_option(ld, option, ref value);
-        
+
         internal override int ldap_unbind_s(IntPtr ld) => NativeMethodsLinux.ldap_unbind_s(ld);
 
         internal override int ldap_search_ext(SafeHandle ld, string @base, int scope, string filter, string[] attrs, int attrsonly,
@@ -235,8 +235,8 @@ namespace LdapForNet.Native
             NativeMethodsLinux.ldap_search_ext(ld, @base, scope, filter, attrs, attrsonly,
                 serverctrls, clientctrls, timeout, sizelimit, ref msgidp);
 
-        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) => 
-            NativeMethodsLinux.ldap_result(ld,msgid,all,timeout,ref pMessage);
+        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) =>
+            NativeMethodsLinux.ldap_result(ld, msgid, all, timeout, ref pMessage);
 
         internal override int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp,
             ref IntPtr referralsp, ref IntPtr serverctrlsp, int freeit) =>
@@ -302,8 +302,8 @@ namespace LdapForNet.Native
             IntPtr clientctrls, ref int msgidp) =>
             NativeMethodsLinux.ldap_extended_operation(ld, requestoid, requestdata, serverctrls, clientctrls, ref msgidp);
 
-        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) => 
-            NativeMethodsLinux.ldap_parse_extended_result(ldapHandle, result, ref  oid, ref data,freeIt);
+        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) =>
+            NativeMethodsLinux.ldap_parse_extended_result(ldapHandle, result, ref oid, ref data, freeIt);
 
         internal override void ldap_controls_free(IntPtr ctrls) => NativeMethodsLinux.ldap_controls_free(ctrls);
     }

--- a/LdapForNet/Native/LdapNativeLinux.cs
+++ b/LdapForNet/Native/LdapNativeLinux.cs
@@ -5,13 +5,13 @@ using System.Threading.Tasks;
 
 namespace LdapForNet.Native
 {
-    internal class LdapNativeLinux : LdapNative
+    internal class LdapNativeLinux:LdapNative
     {
-        internal override int Init(ref IntPtr ld, Uri uri) =>
-            NativeMethodsLinux.ldap_initialize(ref ld, uri.ToString());
+		internal override int Init(ref IntPtr ld, Uri uri) =>
+			NativeMethodsLinux.ldap_initialize(ref ld, uri.ToString());
 
-        internal override int Init(ref IntPtr ld, string hostname, int port) =>
-            NativeMethodsLinux.ldap_initialize(ref ld, $"LDAP://{hostname}:{port}");
+		internal override int Init(ref IntPtr ld, string hostname, int port) => 
+            NativeMethodsLinux.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)
         {
@@ -22,13 +22,13 @@ namespace LdapForNet.Native
             return NativeMethodsLinux.ldap_sasl_interactive_bind_s(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
                 (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET, (l, flags, d, interact) => (int)Native.ResultCode.Success, ptr);
         }
-
+        
         private Native.LdapSaslDefaults GetSaslDefaults(SafeHandle ld)
         {
             var defaults = new Native.LdapSaslDefaults { mech = Native.LdapAuthMechanism.GSSAPI };
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm), nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid), nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid), nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm),nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid),nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid),nameof(ldap_get_option));
             return defaults;
         }
 
@@ -47,10 +47,10 @@ namespace LdapForNet.Native
                 do
                 {
                     rc = NativeMethodsLinux.ldap_sasl_interactive_bind(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
-                        (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET,
-                        SaslInteractProc, ptr, result, ref rmech,
+                        (uint) Native.LdapInteractionFlags.LDAP_SASL_QUIET,
+                        SaslInteractProc , ptr, result, ref rmech,
                         ref msgid);
-                    if (rc != (int)Native.ResultCode.SaslBindInProgress)
+                    if (rc != (int) Native.ResultCode.SaslBindInProgress)
                     {
                         break;
                     }
@@ -58,17 +58,17 @@ namespace LdapForNet.Native
 
                     if (ldap_result(ld, msgid, 0, IntPtr.Zero, ref result) == Native.LdapResultType.LDAP_ERROR)
                     {
-                        ThrowIfError(rc, nameof(NativeMethodsLinux.ldap_sasl_interactive_bind));
+                        ThrowIfError(rc,nameof(NativeMethodsLinux.ldap_sasl_interactive_bind));
                     }
 
                     if (result == IntPtr.Zero)
                     {
                         throw new LdapException("Result is not initialized", nameof(NativeMethodsLinux.ldap_sasl_interactive_bind), 1);
                     }
-
-                } while (rc == (int)Native.ResultCode.SaslBindInProgress);
-
-                ThrowIfError(ld, rc, nameof(NativeMethodsLinux.ldap_sasl_interactive_bind), new Dictionary<string, string>
+                    
+                } while (rc == (int) Native.ResultCode.SaslBindInProgress);
+                
+                ThrowIfError(ld,rc, nameof(NativeMethodsLinux.ldap_sasl_interactive_bind), new Dictionary<string, string>
                 {
                     [nameof(saslDefaults)] = saslDefaults.ToString()
                 });
@@ -76,8 +76,8 @@ namespace LdapForNet.Native
             });
             return await task.ConfigureAwait(false);
         }
-
-
+        
+        
         private static int SaslInteractProc(IntPtr ld, uint flags, IntPtr d, IntPtr @in)
         {
             var ptr = @in;
@@ -92,7 +92,7 @@ namespace LdapForNet.Native
             while (interact.id != (int)Native.SaslCb.SASL_CB_LIST_END)
             {
                 var rc = SaslInteraction(flags, interact, defaults);
-                if (rc != (int)Native.ResultCode.Success)
+                if (rc != (int) Native.ResultCode.Success)
                 {
                     return rc;
                 }
@@ -101,7 +101,7 @@ namespace LdapForNet.Native
                 interact = Marshal.PtrToStructure<Native.SaslInteract>(ptr);
             }
 
-            return (int)Native.ResultCode.Success;
+            return (int) Native.ResultCode.Success;
         }
 
         private static int SaslInteraction(uint flags, Native.SaslInteract interact, Native.LdapSaslDefaults defaults)
@@ -143,13 +143,13 @@ namespace LdapForNet.Native
             if (flags != (uint)Native.LdapInteractionFlags.LDAP_SASL_INTERACTIVE && (interact.id == (int)Native.SaslCb.SASL_CB_USER || !string.IsNullOrEmpty(interact.defresult)))
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
-                return (int)Native.ResultCode.Success;
+                interact.len = interact.defresult != null?(ushort)interact.defresult.Length:(ushort)0;
+                return (int) Native.ResultCode.Success;
             }
 
-            if (flags == (int)Native.LdapInteractionFlags.LDAP_SASL_QUIET)
+            if (flags == (int) Native.LdapInteractionFlags.LDAP_SASL_QUIET)
             {
-                return (int)Native.ResultCode.Other;
+                return (int) Native.ResultCode.Other;
             }
 
             if (noecho)
@@ -171,10 +171,10 @@ namespace LdapForNet.Native
             else
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
+                interact.len = interact.defresult != null ? (ushort) interact.defresult.Length : (ushort)0;
             }
 
-            return (int)Native.ResultCode.Success;
+            return (int) Native.ResultCode.Success;
         }
 
 
@@ -183,7 +183,7 @@ namespace LdapForNet.Native
 
         internal override async Task<IntPtr> BindSimpleAsync(SafeHandle _ld, string userDn, string password)
         {
-
+            
             return await Task.Factory.StartNew(() =>
             {
                 var berval = new Native.berval
@@ -192,42 +192,42 @@ namespace LdapForNet.Native
                     bv_val = Marshal.StringToHGlobalAnsi(password)
                 };
                 var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(berval));
-                Marshal.StructureToPtr(berval, ptr, false);
+                Marshal.StructureToPtr(berval,ptr,false);
                 var msgidp = 0;
                 var result = IntPtr.Zero;
                 NativeMethodsLinux.ldap_sasl_bind(_ld, userDn, null, ptr, IntPtr.Zero, IntPtr.Zero, ref msgidp);
                 if (msgidp == -1)
                 {
-                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsLinux.ldap_sasl_bind)} returns wrong or empty result", nameof(NativeMethodsLinux.ldap_sasl_bind), 1);
+                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsLinux.ldap_sasl_bind)} returns wrong or empty result",  nameof(NativeMethodsLinux.ldap_sasl_bind), 1);
                 }
 
                 var rc = ldap_result(_ld, msgidp, 0, IntPtr.Zero, ref result);
 
                 if (rc == Native.LdapResultType.LDAP_ERROR || rc == Native.LdapResultType.LDAP_TIMEOUT)
                 {
-                    ThrowIfError((int)rc, nameof(NativeMethodsLinux.ldap_sasl_bind));
+                    ThrowIfError((int)rc,nameof(NativeMethodsLinux.ldap_sasl_bind));
                 }
 
                 return result;
             }).ConfigureAwait(false);
         }
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue)
+        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue) 
             => NativeMethodsLinux.ldap_set_option(ld, option, ref invalue);
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue) =>
+        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue)=>
             NativeMethodsLinux.ldap_set_option(ld, option, ref invalue);
 
         internal override int ldap_set_option(SafeHandle ld, int option, IntPtr invalue)
-            => NativeMethodsLinux.ldap_set_option(ld, option, invalue);
+            => NativeMethodsLinux.ldap_set_option(ld, option,  invalue);
 
 
-        internal override int ldap_get_option(SafeHandle ld, int option, ref string value)
+        internal override int ldap_get_option(SafeHandle ld, int option, ref string value) 
             => NativeMethodsLinux.ldap_get_option(ld, option, ref value);
 
         internal override int ldap_get_option(SafeHandle ld, int option, ref IntPtr value)
             => NativeMethodsLinux.ldap_get_option(ld, option, ref value);
-
+        
         internal override int ldap_unbind_s(IntPtr ld) => NativeMethodsLinux.ldap_unbind_s(ld);
 
         internal override int ldap_search_ext(SafeHandle ld, string @base, int scope, string filter, string[] attrs, int attrsonly,
@@ -235,8 +235,8 @@ namespace LdapForNet.Native
             NativeMethodsLinux.ldap_search_ext(ld, @base, scope, filter, attrs, attrsonly,
                 serverctrls, clientctrls, timeout, sizelimit, ref msgidp);
 
-        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) =>
-            NativeMethodsLinux.ldap_result(ld, msgid, all, timeout, ref pMessage);
+        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) => 
+            NativeMethodsLinux.ldap_result(ld,msgid,all,timeout,ref pMessage);
 
         internal override int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp,
             ref IntPtr referralsp, ref IntPtr serverctrlsp, int freeit) =>
@@ -302,8 +302,8 @@ namespace LdapForNet.Native
             IntPtr clientctrls, ref int msgidp) =>
             NativeMethodsLinux.ldap_extended_operation(ld, requestoid, requestdata, serverctrls, clientctrls, ref msgidp);
 
-        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) =>
-            NativeMethodsLinux.ldap_parse_extended_result(ldapHandle, result, ref oid, ref data, freeIt);
+        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) => 
+            NativeMethodsLinux.ldap_parse_extended_result(ldapHandle, result, ref  oid, ref data,freeIt);
 
         internal override void ldap_controls_free(IntPtr ctrls) => NativeMethodsLinux.ldap_controls_free(ctrls);
     }

--- a/LdapForNet/Native/LdapNativeLinux.cs
+++ b/LdapForNet/Native/LdapNativeLinux.cs
@@ -7,10 +7,10 @@ namespace LdapForNet.Native
 {
     internal class LdapNativeLinux:LdapNative
     {
-		internal override int Init(ref IntPtr ld, Uri uri) =>
-			NativeMethodsLinux.ldap_initialize(ref ld, uri.ToString());
+        internal override int Init(ref IntPtr ld, Uri uri) =>
+            NativeMethodsLinux.ldap_initialize(ref ld, uri.ToString());
 
-		internal override int Init(ref IntPtr ld, string hostname, int port) => 
+        internal override int Init(ref IntPtr ld, string hostname, int port) => 
             NativeMethodsLinux.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)

--- a/LdapForNet/Native/LdapNativeLinux.cs
+++ b/LdapForNet/Native/LdapNativeLinux.cs
@@ -7,7 +7,10 @@ namespace LdapForNet.Native
 {
     internal class LdapNativeLinux:LdapNative
     {
-        internal override int Init(ref IntPtr ld, string hostname, int port) => 
+		internal override int Init(ref IntPtr ld, Uri uri) =>
+			NativeMethodsLinux.ldap_initialize(ref ld, uri.ToString());
+
+		internal override int Init(ref IntPtr ld, string hostname, int port) => 
             NativeMethodsLinux.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)

--- a/LdapForNet/Native/LdapNativeOsx.cs
+++ b/LdapForNet/Native/LdapNativeOsx.cs
@@ -7,10 +7,10 @@ namespace LdapForNet.Native
 {
     internal class LdapNativeOsx:LdapNative
     {
-		internal override int Init(ref IntPtr ld, Uri uri) =>
-			NativeMethodsOsx.ldap_initialize(ref ld, uri.ToString());
+        internal override int Init(ref IntPtr ld, Uri uri) =>
+            NativeMethodsOsx.ldap_initialize(ref ld, uri.ToString());
 
-		internal override int Init(ref IntPtr ld, string hostname, int port) => 
+        internal override int Init(ref IntPtr ld, string hostname, int port) => 
             NativeMethodsOsx.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)

--- a/LdapForNet/Native/LdapNativeOsx.cs
+++ b/LdapForNet/Native/LdapNativeOsx.cs
@@ -5,13 +5,13 @@ using System.Threading.Tasks;
 
 namespace LdapForNet.Native
 {
-    internal class LdapNativeOsx:LdapNative
+    internal class LdapNativeOsx : LdapNative
     {
-		internal override int Init(ref IntPtr ld, Uri uri) =>
-			NativeMethodsOsx.ldap_initialize(ref ld, uri.ToString());
+        internal override int Init(ref IntPtr ld, Uri uri) =>
+            NativeMethodsOsx.ldap_initialize(ref ld, uri.ToString());
 
-		internal override int Init(ref IntPtr ld, string hostname, int port) => 
-            NativeMethodsOsx.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
+        internal override int Init(ref IntPtr ld, string hostname, int port) =>
+            NativeMethodsOsx.ldap_initialize(ref ld, $"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)
         {
@@ -22,13 +22,13 @@ namespace LdapForNet.Native
             return NativeMethodsOsx.ldap_sasl_interactive_bind_s(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
                 (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET, (l, flags, d, interact) => (int)Native.ResultCode.Success, ptr);
         }
-        
+
         private Native.LdapSaslDefaults GetSaslDefaults(SafeHandle ld)
         {
             var defaults = new Native.LdapSaslDefaults { mech = Native.LdapAuthMechanism.GSSAPI };
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm),nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid),nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid),nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm), nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid), nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid), nameof(ldap_get_option));
             return defaults;
         }
 
@@ -47,10 +47,10 @@ namespace LdapForNet.Native
                 do
                 {
                     rc = NativeMethodsOsx.ldap_sasl_interactive_bind(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
-                        (uint) Native.LdapInteractionFlags.LDAP_SASL_QUIET,
-                        SaslInteractProc , ptr, result, ref rmech,
+                        (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET,
+                        SaslInteractProc, ptr, result, ref rmech,
                         ref msgid);
-                    if (rc != (int) Native.ResultCode.SaslBindInProgress)
+                    if (rc != (int)Native.ResultCode.SaslBindInProgress)
                     {
                         break;
                     }
@@ -58,17 +58,17 @@ namespace LdapForNet.Native
 
                     if (NativeMethodsOsx.ldap_result(ld, msgid, 0, IntPtr.Zero, ref result) == Native.LdapResultType.LDAP_ERROR)
                     {
-                        ThrowIfError(rc,nameof(NativeMethodsOsx.ldap_sasl_interactive_bind));
+                        ThrowIfError(rc, nameof(NativeMethodsOsx.ldap_sasl_interactive_bind));
                     }
 
                     if (result == IntPtr.Zero)
                     {
                         throw new LdapException("Result is not initialized", nameof(NativeMethodsOsx.ldap_sasl_interactive_bind), 1);
                     }
-                    
-                } while (rc == (int) Native.ResultCode.SaslBindInProgress);
-                
-                ThrowIfError(ld,rc, nameof(NativeMethodsOsx.ldap_sasl_interactive_bind), new Dictionary<string, string>
+
+                } while (rc == (int)Native.ResultCode.SaslBindInProgress);
+
+                ThrowIfError(ld, rc, nameof(NativeMethodsOsx.ldap_sasl_interactive_bind), new Dictionary<string, string>
                 {
                     [nameof(saslDefaults)] = saslDefaults.ToString()
                 });
@@ -76,8 +76,8 @@ namespace LdapForNet.Native
             });
             return await task.ConfigureAwait(false);
         }
-        
-        
+
+
         private static int SaslInteractProc(IntPtr ld, uint flags, IntPtr d, IntPtr @in)
         {
             var ptr = @in;
@@ -92,7 +92,7 @@ namespace LdapForNet.Native
             while (interact.id != (int)Native.SaslCb.SASL_CB_LIST_END)
             {
                 var rc = SaslInteraction(flags, interact, defaults);
-                if (rc != (int) Native.ResultCode.Success)
+                if (rc != (int)Native.ResultCode.Success)
                 {
                     return rc;
                 }
@@ -101,7 +101,7 @@ namespace LdapForNet.Native
                 interact = Marshal.PtrToStructure<Native.SaslInteract>(ptr);
             }
 
-            return (int) Native.ResultCode.Success;
+            return (int)Native.ResultCode.Success;
         }
 
         private static int SaslInteraction(uint flags, Native.SaslInteract interact, Native.LdapSaslDefaults defaults)
@@ -143,13 +143,13 @@ namespace LdapForNet.Native
             if (flags != (uint)Native.LdapInteractionFlags.LDAP_SASL_INTERACTIVE && (interact.id == (int)Native.SaslCb.SASL_CB_USER || !string.IsNullOrEmpty(interact.defresult)))
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null?(ushort)interact.defresult.Length:(ushort)0;
-                return (int) Native.ResultCode.Success;
+                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
+                return (int)Native.ResultCode.Success;
             }
 
-            if (flags == (int) Native.LdapInteractionFlags.LDAP_SASL_QUIET)
+            if (flags == (int)Native.LdapInteractionFlags.LDAP_SASL_QUIET)
             {
-                return (int) Native.ResultCode.Other;
+                return (int)Native.ResultCode.Other;
             }
 
             if (noecho)
@@ -171,10 +171,10 @@ namespace LdapForNet.Native
             else
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null ? (ushort) interact.defresult.Length : (ushort)0;
+                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
             }
 
-            return (int) Native.ResultCode.Success;
+            return (int)Native.ResultCode.Success;
         }
 
 
@@ -183,7 +183,7 @@ namespace LdapForNet.Native
 
         internal override async Task<IntPtr> BindSimpleAsync(SafeHandle _ld, string userDn, string password)
         {
-            
+
             return await Task.Factory.StartNew(() =>
             {
                 var berval = new Native.berval
@@ -192,42 +192,42 @@ namespace LdapForNet.Native
                     bv_val = Marshal.StringToHGlobalAnsi(password)
                 };
                 var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(berval));
-                Marshal.StructureToPtr(berval,ptr,false);
+                Marshal.StructureToPtr(berval, ptr, false);
                 var msgidp = 0;
                 var result = IntPtr.Zero;
                 NativeMethodsOsx.ldap_sasl_bind(_ld, userDn, null, ptr, IntPtr.Zero, IntPtr.Zero, ref msgidp);
                 if (msgidp == -1)
                 {
-                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsOsx.ldap_sasl_bind)} returns wrong or empty result",  nameof(NativeMethodsOsx.ldap_sasl_bind), 1);
+                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsOsx.ldap_sasl_bind)} returns wrong or empty result", nameof(NativeMethodsOsx.ldap_sasl_bind), 1);
                 }
 
                 var rc = NativeMethodsOsx.ldap_result(_ld, msgidp, 0, IntPtr.Zero, ref result);
 
                 if (rc == Native.LdapResultType.LDAP_ERROR || rc == Native.LdapResultType.LDAP_TIMEOUT)
                 {
-                    ThrowIfError((int)rc,nameof(NativeMethodsOsx.ldap_sasl_bind));
+                    ThrowIfError((int)rc, nameof(NativeMethodsOsx.ldap_sasl_bind));
                 }
 
                 return result;
             }).ConfigureAwait(false);
         }
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue) 
+        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue)
             => NativeMethodsOsx.ldap_set_option(ld, option, ref invalue);
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue)=>
+        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue) =>
             NativeMethodsOsx.ldap_set_option(ld, option, ref invalue);
 
         internal override int ldap_set_option(SafeHandle ld, int option, IntPtr invalue)
-            => NativeMethodsOsx.ldap_set_option(ld, option,  invalue);
+            => NativeMethodsOsx.ldap_set_option(ld, option, invalue);
 
 
-        internal override int ldap_get_option(SafeHandle ld, int option, ref string value) 
+        internal override int ldap_get_option(SafeHandle ld, int option, ref string value)
             => NativeMethodsOsx.ldap_get_option(ld, option, ref value);
 
         internal override int ldap_get_option(SafeHandle ld, int option, ref IntPtr value)
             => NativeMethodsOsx.ldap_get_option(ld, option, ref value);
-        
+
         internal override int ldap_unbind_s(IntPtr ld) => NativeMethodsOsx.ldap_unbind_s(ld);
 
         internal override int ldap_search_ext(SafeHandle ld, string @base, int scope, string filter, string[] attrs, int attrsonly,
@@ -235,8 +235,8 @@ namespace LdapForNet.Native
             NativeMethodsOsx.ldap_search_ext(ld, @base, scope, filter, attrs, attrsonly,
                 serverctrls, clientctrls, timeout, sizelimit, ref msgidp);
 
-        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) => 
-            NativeMethodsOsx.ldap_result(ld,msgid,all,timeout,ref pMessage);
+        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) =>
+            NativeMethodsOsx.ldap_result(ld, msgid, all, timeout, ref pMessage);
 
         internal override int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp,
             ref IntPtr referralsp, ref IntPtr serverctrlsp, int freeit) =>
@@ -300,9 +300,9 @@ namespace LdapForNet.Native
             IntPtr clientctrls, ref int msgidp) =>
             NativeMethodsOsx.ldap_rename(ld, dn, newrdn, newparent, deleteoldrdn, serverctrls, clientctrls, ref msgidp);
 
-        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) => 
-            NativeMethodsOsx.ldap_parse_extended_result(ldapHandle, result, ref  oid, ref data,freeIt);
-        
+        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) =>
+            NativeMethodsOsx.ldap_parse_extended_result(ldapHandle, result, ref oid, ref data, freeIt);
+
         internal override void ldap_controls_free(IntPtr ctrls) => NativeMethodsOsx.ldap_controls_free(ctrls);
     }
 }

--- a/LdapForNet/Native/LdapNativeOsx.cs
+++ b/LdapForNet/Native/LdapNativeOsx.cs
@@ -7,7 +7,10 @@ namespace LdapForNet.Native
 {
     internal class LdapNativeOsx:LdapNative
     {
-        internal override int Init(ref IntPtr ld, string hostname, int port) => 
+		internal override int Init(ref IntPtr ld, Uri uri) =>
+			NativeMethodsOsx.ldap_initialize(ref ld, uri.ToString());
+
+		internal override int Init(ref IntPtr ld, string hostname, int port) => 
             NativeMethodsOsx.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)

--- a/LdapForNet/Native/LdapNativeOsx.cs
+++ b/LdapForNet/Native/LdapNativeOsx.cs
@@ -5,13 +5,13 @@ using System.Threading.Tasks;
 
 namespace LdapForNet.Native
 {
-    internal class LdapNativeOsx : LdapNative
+    internal class LdapNativeOsx:LdapNative
     {
-        internal override int Init(ref IntPtr ld, Uri uri) =>
-            NativeMethodsOsx.ldap_initialize(ref ld, uri.ToString());
+		internal override int Init(ref IntPtr ld, Uri uri) =>
+			NativeMethodsOsx.ldap_initialize(ref ld, uri.ToString());
 
-        internal override int Init(ref IntPtr ld, string hostname, int port) =>
-            NativeMethodsOsx.ldap_initialize(ref ld, $"LDAP://{hostname}:{port}");
+		internal override int Init(ref IntPtr ld, string hostname, int port) => 
+            NativeMethodsOsx.ldap_initialize(ref ld,$"LDAP://{hostname}:{port}");
 
         internal override int BindKerberos(SafeHandle ld)
         {
@@ -22,13 +22,13 @@ namespace LdapForNet.Native
             return NativeMethodsOsx.ldap_sasl_interactive_bind_s(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
                 (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET, (l, flags, d, interact) => (int)Native.ResultCode.Success, ptr);
         }
-
+        
         private Native.LdapSaslDefaults GetSaslDefaults(SafeHandle ld)
         {
             var defaults = new Native.LdapSaslDefaults { mech = Native.LdapAuthMechanism.GSSAPI };
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm), nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid), nameof(ldap_get_option));
-            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid), nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_REALM, ref defaults.realm),nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref defaults.authcid),nameof(ldap_get_option));
+            ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref defaults.authzid),nameof(ldap_get_option));
             return defaults;
         }
 
@@ -47,10 +47,10 @@ namespace LdapForNet.Native
                 do
                 {
                     rc = NativeMethodsOsx.ldap_sasl_interactive_bind(ld, null, Native.LdapAuthMechanism.GSSAPI, IntPtr.Zero, IntPtr.Zero,
-                        (uint)Native.LdapInteractionFlags.LDAP_SASL_QUIET,
-                        SaslInteractProc, ptr, result, ref rmech,
+                        (uint) Native.LdapInteractionFlags.LDAP_SASL_QUIET,
+                        SaslInteractProc , ptr, result, ref rmech,
                         ref msgid);
-                    if (rc != (int)Native.ResultCode.SaslBindInProgress)
+                    if (rc != (int) Native.ResultCode.SaslBindInProgress)
                     {
                         break;
                     }
@@ -58,17 +58,17 @@ namespace LdapForNet.Native
 
                     if (NativeMethodsOsx.ldap_result(ld, msgid, 0, IntPtr.Zero, ref result) == Native.LdapResultType.LDAP_ERROR)
                     {
-                        ThrowIfError(rc, nameof(NativeMethodsOsx.ldap_sasl_interactive_bind));
+                        ThrowIfError(rc,nameof(NativeMethodsOsx.ldap_sasl_interactive_bind));
                     }
 
                     if (result == IntPtr.Zero)
                     {
                         throw new LdapException("Result is not initialized", nameof(NativeMethodsOsx.ldap_sasl_interactive_bind), 1);
                     }
-
-                } while (rc == (int)Native.ResultCode.SaslBindInProgress);
-
-                ThrowIfError(ld, rc, nameof(NativeMethodsOsx.ldap_sasl_interactive_bind), new Dictionary<string, string>
+                    
+                } while (rc == (int) Native.ResultCode.SaslBindInProgress);
+                
+                ThrowIfError(ld,rc, nameof(NativeMethodsOsx.ldap_sasl_interactive_bind), new Dictionary<string, string>
                 {
                     [nameof(saslDefaults)] = saslDefaults.ToString()
                 });
@@ -76,8 +76,8 @@ namespace LdapForNet.Native
             });
             return await task.ConfigureAwait(false);
         }
-
-
+        
+        
         private static int SaslInteractProc(IntPtr ld, uint flags, IntPtr d, IntPtr @in)
         {
             var ptr = @in;
@@ -92,7 +92,7 @@ namespace LdapForNet.Native
             while (interact.id != (int)Native.SaslCb.SASL_CB_LIST_END)
             {
                 var rc = SaslInteraction(flags, interact, defaults);
-                if (rc != (int)Native.ResultCode.Success)
+                if (rc != (int) Native.ResultCode.Success)
                 {
                     return rc;
                 }
@@ -101,7 +101,7 @@ namespace LdapForNet.Native
                 interact = Marshal.PtrToStructure<Native.SaslInteract>(ptr);
             }
 
-            return (int)Native.ResultCode.Success;
+            return (int) Native.ResultCode.Success;
         }
 
         private static int SaslInteraction(uint flags, Native.SaslInteract interact, Native.LdapSaslDefaults defaults)
@@ -143,13 +143,13 @@ namespace LdapForNet.Native
             if (flags != (uint)Native.LdapInteractionFlags.LDAP_SASL_INTERACTIVE && (interact.id == (int)Native.SaslCb.SASL_CB_USER || !string.IsNullOrEmpty(interact.defresult)))
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
-                return (int)Native.ResultCode.Success;
+                interact.len = interact.defresult != null?(ushort)interact.defresult.Length:(ushort)0;
+                return (int) Native.ResultCode.Success;
             }
 
-            if (flags == (int)Native.LdapInteractionFlags.LDAP_SASL_QUIET)
+            if (flags == (int) Native.LdapInteractionFlags.LDAP_SASL_QUIET)
             {
-                return (int)Native.ResultCode.Other;
+                return (int) Native.ResultCode.Other;
             }
 
             if (noecho)
@@ -171,10 +171,10 @@ namespace LdapForNet.Native
             else
             {
                 interact.result = Marshal.StringToHGlobalAnsi(interact.defresult);
-                interact.len = interact.defresult != null ? (ushort)interact.defresult.Length : (ushort)0;
+                interact.len = interact.defresult != null ? (ushort) interact.defresult.Length : (ushort)0;
             }
 
-            return (int)Native.ResultCode.Success;
+            return (int) Native.ResultCode.Success;
         }
 
 
@@ -183,7 +183,7 @@ namespace LdapForNet.Native
 
         internal override async Task<IntPtr> BindSimpleAsync(SafeHandle _ld, string userDn, string password)
         {
-
+            
             return await Task.Factory.StartNew(() =>
             {
                 var berval = new Native.berval
@@ -192,42 +192,42 @@ namespace LdapForNet.Native
                     bv_val = Marshal.StringToHGlobalAnsi(password)
                 };
                 var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(berval));
-                Marshal.StructureToPtr(berval, ptr, false);
+                Marshal.StructureToPtr(berval,ptr,false);
                 var msgidp = 0;
                 var result = IntPtr.Zero;
                 NativeMethodsOsx.ldap_sasl_bind(_ld, userDn, null, ptr, IntPtr.Zero, IntPtr.Zero, ref msgidp);
                 if (msgidp == -1)
                 {
-                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsOsx.ldap_sasl_bind)} returns wrong or empty result", nameof(NativeMethodsOsx.ldap_sasl_bind), 1);
+                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsOsx.ldap_sasl_bind)} returns wrong or empty result",  nameof(NativeMethodsOsx.ldap_sasl_bind), 1);
                 }
 
                 var rc = NativeMethodsOsx.ldap_result(_ld, msgidp, 0, IntPtr.Zero, ref result);
 
                 if (rc == Native.LdapResultType.LDAP_ERROR || rc == Native.LdapResultType.LDAP_TIMEOUT)
                 {
-                    ThrowIfError((int)rc, nameof(NativeMethodsOsx.ldap_sasl_bind));
+                    ThrowIfError((int)rc,nameof(NativeMethodsOsx.ldap_sasl_bind));
                 }
 
                 return result;
             }).ConfigureAwait(false);
         }
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue)
+        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue) 
             => NativeMethodsOsx.ldap_set_option(ld, option, ref invalue);
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue) =>
+        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue)=>
             NativeMethodsOsx.ldap_set_option(ld, option, ref invalue);
 
         internal override int ldap_set_option(SafeHandle ld, int option, IntPtr invalue)
-            => NativeMethodsOsx.ldap_set_option(ld, option, invalue);
+            => NativeMethodsOsx.ldap_set_option(ld, option,  invalue);
 
 
-        internal override int ldap_get_option(SafeHandle ld, int option, ref string value)
+        internal override int ldap_get_option(SafeHandle ld, int option, ref string value) 
             => NativeMethodsOsx.ldap_get_option(ld, option, ref value);
 
         internal override int ldap_get_option(SafeHandle ld, int option, ref IntPtr value)
             => NativeMethodsOsx.ldap_get_option(ld, option, ref value);
-
+        
         internal override int ldap_unbind_s(IntPtr ld) => NativeMethodsOsx.ldap_unbind_s(ld);
 
         internal override int ldap_search_ext(SafeHandle ld, string @base, int scope, string filter, string[] attrs, int attrsonly,
@@ -235,8 +235,8 @@ namespace LdapForNet.Native
             NativeMethodsOsx.ldap_search_ext(ld, @base, scope, filter, attrs, attrsonly,
                 serverctrls, clientctrls, timeout, sizelimit, ref msgidp);
 
-        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) =>
-            NativeMethodsOsx.ldap_result(ld, msgid, all, timeout, ref pMessage);
+        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) => 
+            NativeMethodsOsx.ldap_result(ld,msgid,all,timeout,ref pMessage);
 
         internal override int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp,
             ref IntPtr referralsp, ref IntPtr serverctrlsp, int freeit) =>
@@ -300,9 +300,9 @@ namespace LdapForNet.Native
             IntPtr clientctrls, ref int msgidp) =>
             NativeMethodsOsx.ldap_rename(ld, dn, newrdn, newparent, deleteoldrdn, serverctrls, clientctrls, ref msgidp);
 
-        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) =>
-            NativeMethodsOsx.ldap_parse_extended_result(ldapHandle, result, ref oid, ref data, freeIt);
-
+        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) => 
+            NativeMethodsOsx.ldap_parse_extended_result(ldapHandle, result, ref  oid, ref data,freeIt);
+        
         internal override void ldap_controls_free(IntPtr ctrls) => NativeMethodsOsx.ldap_controls_free(ctrls);
     }
 }

--- a/LdapForNet/Native/LdapNativeWindows.cs
+++ b/LdapForNet/Native/LdapNativeWindows.cs
@@ -4,32 +4,32 @@ using System.Threading.Tasks;
 
 namespace LdapForNet.Native
 {
-	internal class LdapNativeWindows : LdapNative
-	{
-		private const string LDAPS = "LDAPS";
-		private const string LDAP = "LDAP";
+    internal class LdapNativeWindows : LdapNative
+    {
+        private const string LDAPS = "LDAPS";
+        private const string LDAP = "LDAP";
 
-		internal override int Init(ref IntPtr ld, Uri uri)
-		{
-			var port = uri.Port;
-			if (uri.IsDefaultPort)
-			{
-				if (string.Compare(uri.Scheme, LDAP, StringComparison.InvariantCultureIgnoreCase) == 0)
-				{
-					port = (int)LdapForNet.Native.Native.LdapPort.LDAP;
-				}
-				else if (string.Compare(uri.Scheme, LDAPS, StringComparison.InvariantCultureIgnoreCase) == 0)
-				{
-					port = (int)LdapForNet.Native.Native.LdapPort.LDAPS;
-				}
-			}
-
-			return Init(ref ld, uri.Host, port);
-		}
-
-		internal override int Init(ref IntPtr ld, string hostname, int port)
+        internal override int Init(ref IntPtr ld, Uri uri)
         {
-            ld =  NativeMethodsWindows.ldap_init(hostname, port);
+            var port = uri.Port;
+            if (uri.IsDefaultPort)
+            {
+                if (string.Compare(uri.Scheme, LDAP, StringComparison.InvariantCultureIgnoreCase) == 0)
+                {
+                    port = (int)LdapForNet.Native.Native.LdapPort.LDAP;
+                }
+                else if (string.Compare(uri.Scheme, LDAPS, StringComparison.InvariantCultureIgnoreCase) == 0)
+                {
+                    port = (int)LdapForNet.Native.Native.LdapPort.LDAPS;
+                }
+            }
+
+            return Init(ref ld, uri.Host, port);
+        }
+
+        internal override int Init(ref IntPtr ld, string hostname, int port)
+        {
+            ld = NativeMethodsWindows.ldap_init(hostname, port);
             if (ld == IntPtr.Zero)
             {
                 return -1;
@@ -43,7 +43,7 @@ namespace LdapForNet.Native
             {
                 tv_sec = (int)(TimeSpan.FromMinutes(10).Ticks / TimeSpan.TicksPerSecond)
             };
-            ThrowIfError(NativeMethodsWindows.ldap_connect(ld, timeout),nameof(NativeMethodsWindows.ldap_connect));
+            ThrowIfError(NativeMethodsWindows.ldap_connect(ld, timeout), nameof(NativeMethodsWindows.ldap_connect));
         }
 
         internal override int BindKerberos(SafeHandle ld)
@@ -70,7 +70,7 @@ namespace LdapForNet.Native
 
             var task = Task.Factory.StartNew(() =>
             {
-                ThrowIfError(NativeMethodsWindows.ldap_bind_s(ld, null, cred, BindMethod.LDAP_AUTH_NEGOTIATE),nameof(NativeMethodsWindows.ldap_bind_s));
+                ThrowIfError(NativeMethodsWindows.ldap_bind_s(ld, null, cred, BindMethod.LDAP_AUTH_NEGOTIATE), nameof(NativeMethodsWindows.ldap_bind_s));
 
                 return IntPtr.Zero;
             });
@@ -94,42 +94,42 @@ namespace LdapForNet.Native
                     bv_val = Marshal.StringToHGlobalAnsi(password)
                 };
                 var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(berval));
-                Marshal.StructureToPtr(berval,ptr,false);
+                Marshal.StructureToPtr(berval, ptr, false);
                 var result = IntPtr.Zero;
                 var msgidp = NativeMethodsWindows.ldap_simple_bind(ld, who, password);
-  
+
                 if (msgidp == -1)
                 {
-                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsWindows.ldap_simple_bind)} returns wrong or empty result",  nameof(NativeMethodsWindows.ldap_simple_bind), 1);
+                    throw new LdapException($"{nameof(BindSimpleAsync)} failed. {nameof(NativeMethodsWindows.ldap_simple_bind)} returns wrong or empty result", nameof(NativeMethodsWindows.ldap_simple_bind), 1);
                 }
 
                 var rc = ldap_result(ld, msgidp, 0, IntPtr.Zero, ref result);
 
                 if (rc == Native.LdapResultType.LDAP_ERROR || rc == Native.LdapResultType.LDAP_TIMEOUT)
                 {
-                    ThrowIfError((int)rc,nameof(NativeMethodsWindows.ldap_simple_bind));
+                    ThrowIfError((int)rc, nameof(NativeMethodsWindows.ldap_simple_bind));
                 }
 
                 return result;
             }).ConfigureAwait(false);
         }
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue) 
+        internal override int ldap_set_option(SafeHandle ld, int option, ref int invalue)
             => NativeMethodsWindows.ldap_set_option(ld, option, ref invalue);
 
-        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue)=>
+        internal override int ldap_set_option(SafeHandle ld, int option, ref string invalue) =>
             NativeMethodsWindows.ldap_set_option(ld, option, ref invalue);
 
         internal override int ldap_set_option(SafeHandle ld, int option, IntPtr invalue)
-            => NativeMethodsWindows.ldap_set_option(ld, option,  invalue);
+            => NativeMethodsWindows.ldap_set_option(ld, option, invalue);
 
 
-        internal override int ldap_get_option(SafeHandle ld, int option, ref string value) 
+        internal override int ldap_get_option(SafeHandle ld, int option, ref string value)
             => NativeMethodsWindows.ldap_get_option(ld, option, ref value);
 
         internal override int ldap_get_option(SafeHandle ld, int option, ref IntPtr value)
             => NativeMethodsWindows.ldap_get_option(ld, option, ref value);
-        
+
         internal override int ldap_unbind_s(IntPtr ld) => NativeMethodsWindows.ldap_unbind_s(ld);
 
         internal override int ldap_search_ext(SafeHandle ld, string @base, int scope, string filter, string[] attrs, int attrsonly,
@@ -137,8 +137,8 @@ namespace LdapForNet.Native
             NativeMethodsWindows.ldap_search_ext(ld, @base, scope, filter, attrs, attrsonly,
                 serverctrls, clientctrls, timeout, sizelimit, ref msgidp);
 
-        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) => 
-            NativeMethodsWindows.ldap_result(ld,msgid,all,timeout,ref pMessage);
+        internal override Native.LdapResultType ldap_result(SafeHandle ld, int msgid, int all, IntPtr timeout, ref IntPtr pMessage) =>
+            NativeMethodsWindows.ldap_result(ld, msgid, all, timeout, ref pMessage);
 
         internal override int ldap_parse_result(SafeHandle ld, IntPtr result, ref int errcodep, ref IntPtr matcheddnp, ref IntPtr errmsgp,
             ref IntPtr referralsp, ref IntPtr serverctrlsp, int freeit) =>
@@ -188,8 +188,8 @@ namespace LdapForNet.Native
             IntPtr clientctrls, ref int msgidp) =>
             NativeMethodsWindows.ldap_rename(ld, dn, newrdn, newparent, deleteoldrdn, serverctrls, clientctrls, ref msgidp);
 
-        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) => 
-            NativeMethodsWindows.ldap_parse_extended_result(ldapHandle, result, ref  oid, ref data,freeIt);
+        internal override int ldap_parse_extended_result(SafeHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt) =>
+            NativeMethodsWindows.ldap_parse_extended_result(ldapHandle, result, ref oid, ref data, freeIt);
         internal override void ldap_controls_free(IntPtr ctrls) => NativeMethodsWindows.ldap_controls_free(ctrls);
     }
 }

--- a/LdapForNet/Native/LdapNativeWindows.cs
+++ b/LdapForNet/Native/LdapNativeWindows.cs
@@ -4,9 +4,30 @@ using System.Threading.Tasks;
 
 namespace LdapForNet.Native
 {
-    internal class LdapNativeWindows : LdapNative
-    {
-        internal override int Init(ref IntPtr ld, string hostname, int port)
+	internal class LdapNativeWindows : LdapNative
+	{
+		private const string LDAPS = "LDAPS";
+		private const string LDAP = "LDAP";
+
+		internal override int Init(ref IntPtr ld, Uri uri)
+		{
+			var port = uri.Port;
+			if (uri.IsDefaultPort)
+			{
+				if (string.Compare(uri.Scheme, LDAP, StringComparison.InvariantCultureIgnoreCase) == 0)
+				{
+					port = (int)LdapForNet.Native.Native.LdapPort.LDAP;
+				}
+				else if (string.Compare(uri.Scheme, LDAPS, StringComparison.InvariantCultureIgnoreCase) == 0)
+				{
+					port = (int)LdapForNet.Native.Native.LdapPort.LDAPS;
+				}
+			}
+
+			return Init(ref ld, uri.Host, port);
+		}
+
+		internal override int Init(ref IntPtr ld, string hostname, int port)
         {
             ld =  NativeMethodsWindows.ldap_init(hostname, port);
             if (ld == IntPtr.Zero)

--- a/LdapForNet/Native/LdapNativeWindows.cs
+++ b/LdapForNet/Native/LdapNativeWindows.cs
@@ -4,30 +4,30 @@ using System.Threading.Tasks;
 
 namespace LdapForNet.Native
 {
-	internal class LdapNativeWindows : LdapNative
-	{
-		private const string LDAPS = "LDAPS";
-		private const string LDAP = "LDAP";
+    internal class LdapNativeWindows : LdapNative
+    {
+        private const string LDAPS = "LDAPS";
+        private const string LDAP = "LDAP";
 
-		internal override int Init(ref IntPtr ld, Uri uri)
-		{
-			var port = uri.Port;
-			if (uri.IsDefaultPort)
-			{
-				if (string.Compare(uri.Scheme, LDAP, StringComparison.InvariantCultureIgnoreCase) == 0)
-				{
-					port = (int)LdapForNet.Native.Native.LdapPort.LDAP;
-				}
-				else if (string.Compare(uri.Scheme, LDAPS, StringComparison.InvariantCultureIgnoreCase) == 0)
-				{
-					port = (int)LdapForNet.Native.Native.LdapPort.LDAPS;
-				}
-			}
+        internal override int Init(ref IntPtr ld, Uri uri)
+        {
+            var port = uri.Port;
+            if (uri.IsDefaultPort)
+            {
+                if (string.Compare(uri.Scheme, LDAP, StringComparison.InvariantCultureIgnoreCase) == 0)
+                {
+                    port = (int)LdapForNet.Native.Native.LdapPort.LDAP;
+                }
+                else if (string.Compare(uri.Scheme, LDAPS, StringComparison.InvariantCultureIgnoreCase) == 0)
+                {
+                    port = (int)LdapForNet.Native.Native.LdapPort.LDAPS;
+                }
+            }
 
-			return Init(ref ld, uri.Host, port);
-		}
+            return Init(ref ld, uri.Host, port);
+        }
 
-		internal override int Init(ref IntPtr ld, string hostname, int port)
+        internal override int Init(ref IntPtr ld, string hostname, int port)
         {
             ld =  NativeMethodsWindows.ldap_init(hostname, port);
             if (ld == IntPtr.Zero)


### PR DESCRIPTION
This PullRequest solve problem described in the issue #10 
The main problem of this issue is there are no any opportunities to specify SASL_SECPROPS  during connect to server using TSL (such as maxssf for example). 
There is ldap.conf file (/etc/ldap/ldap.conf) which can be used for that purpose. However it is not working during connection by host and port.
According to [openldap documentation](https://www.openldap.org/software/man.cgi?query=ldap.conf&sektion=5&apropos=0&manpath=OpenLDAP+2.4-Release) TLS OPTIONS are used       when an ldaps:// URI is selected
It turned out that section SASL_SECPROPS applies in the same way.
So providing opportunity to connect via URI + editing ldap.conf file in apropriate way (specify maxssf) have solved problem with connection to Active Directory from linux envinroment by ldaps.
