### PR TITLE
Add generic GetValues method for retrieving directory attribute's values

### DIFF
--- a/LdapForNet.Tests/RequestHandlers/SearchRequestHandlerTests.cs
+++ b/LdapForNet.Tests/RequestHandlers/SearchRequestHandlerTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using LdapForNet;
 using LdapForNet.Native;
 using LdapForNet.RequestHandlers;
@@ -46,11 +48,11 @@ namespace LdapForNetTests.RequestHandlers
             var ldapHandle = new LdapHandle(IntPtr.Zero);
             var entry = new IntPtr(1);
             var dn = "cn=admin,dc=example,dc=com";
-            var attribute = new KeyValuePair<string, List<string>>("cn",new List<string>(2){"admin",null});
+            var attribute = new KeyValuePair<string, byte[][]>("cn",new[] { new ASCIIEncoding().GetBytes("admin") });
             var attributeNamePtr = Marshal.StringToHGlobalAnsi(attribute.Key);
             var dnPtr = Marshal.StringToHGlobalAnsi(dn);
-            var valuesPtr = Marshal.AllocHGlobal(IntPtr.Size*attribute.Value.Count);
-            MarshalUtils.StringArrayToPtr(attribute.Value, valuesPtr);
+            var valuesPtr = Marshal.AllocHGlobal(IntPtr.Size*(attribute.Value.Length+1));
+            MarshalUtils.ByteArraysToBerValueArray(attribute.Value, valuesPtr);
             
             native.Setup(_ => _.ldap_first_entry(ldapHandle, msg))
                 .Returns(entry);
@@ -64,9 +66,9 @@ namespace LdapForNetTests.RequestHandlers
                 .Returns(attributeNamePtr);
             native.Setup(_ => _.ldap_next_attribute(ldapHandle, entry, It.IsAny<IntPtr>()))
                 .Returns(IntPtr.Zero);
-            native.Setup(_ => _.ldap_get_values(ldapHandle, entry, attributeNamePtr))
+            native.Setup(_ => _.ldap_get_values_len(ldapHandle, entry, attributeNamePtr))
                 .Returns(valuesPtr);
-            native.Setup(_ => _.ldap_value_free(It.IsAny<IntPtr>()))
+            native.Setup(_ => _.ldap_value_free_len(It.IsAny<IntPtr>()))
                 .Callback((IntPtr ptr) => Marshal.FreeHGlobal(ptr));
             
             var status = requestHandler.Handle(ldapHandle,
@@ -82,8 +84,8 @@ namespace LdapForNetTests.RequestHandlers
             Assert.Single(searchResult.Entries);
             Assert.Equal(dn,searchResult.Entries[0].Dn);
             Assert.Single(searchResult.Entries[0].Attributes);
-            Assert.True(searchResult.Entries[0].Attributes.ContainsKey(attribute.Key));
-            Assert.Equal(attribute.Value[0], searchResult.Entries[0].Attributes[attribute.Key][0]);
+            Assert.True(searchResult.Entries[0].Attributes.Exists(_=>_.Name == attribute.Key));
+            Assert.Equal(attribute.Value[0], searchResult.Entries[0].Attributes.Find(_=>_.Name == attribute.Key).GetValues<byte[]>().First());
         }
 
         private static SearchRequestHandler CreateRequestHandler(IMock<LdapNative> native)

--- a/LdapForNet.Tests/RequestHandlers/SearchRequestHandlerTests.cs
+++ b/LdapForNet.Tests/RequestHandlers/SearchRequestHandlerTests.cs
@@ -84,8 +84,8 @@ namespace LdapForNetTests.RequestHandlers
             Assert.Single(searchResult.Entries);
             Assert.Equal(dn,searchResult.Entries[0].Dn);
             Assert.Single(searchResult.Entries[0].Attributes);
-            Assert.True(searchResult.Entries[0].Attributes.Exists(_=>_.Name == attribute.Key));
-            Assert.Equal(attribute.Value[0], searchResult.Entries[0].Attributes.Find(_=>_.Name == attribute.Key).GetValues<byte[]>().First());
+            Assert.True(searchResult.Entries[0].Attributes.Contains(attribute.Key));
+            Assert.Equal(attribute.Value[0], searchResult.Entries[0].Attributes[attribute.Key].GetValues<byte[]>().First());
         }
 
         private static SearchRequestHandler CreateRequestHandler(IMock<LdapNative> native)

--- a/LdapForNet/DirectoryResponse.cs
+++ b/LdapForNet/DirectoryResponse.cs
@@ -12,7 +12,7 @@ namespace LdapForNet
     
     public class SearchResponse : DirectoryResponse
     {
-        public List<LdapEntry> Entries { get; internal set; } = new List<LdapEntry>();
+        public List<DirectoryEntry> Entries { get; internal set; } = new List<DirectoryEntry>();
     }
 
     public class AddResponse : DirectoryResponse

--- a/LdapForNet/ILdapConnection.cs
+++ b/LdapForNet/ILdapConnection.cs
@@ -8,6 +8,7 @@ namespace LdapForNet
 {
     public interface ILdapConnection : IDisposable
     {
+        void Connect(Uri uri, LdapVersion version = Native.Native.LdapVersion.LDAP_VERSION3);
         void Connect(string hostname, int port = (int)LdapPort.LDAP, LdapVersion version = LdapVersion.LDAP_VERSION3);
         void Bind(string mechanism = LdapAuthMechanism.GSSAPI, string userDn = null, string password = null);
         Task BindAsync(string mechanism = LdapAuthMechanism.GSSAPI, string userDn = null, string password = null);

--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -116,7 +116,9 @@ namespace LdapForNet
             {
                 ThrowIfResponseError(response);
             }
-            return response.Entries;
+            return response.Entries
+                .Select(_=>_.ToLdapEntry())
+                .ToList();
         }
 
         public async Task<IList<LdapEntry>> SearchAsync(string @base, string filter,
@@ -128,7 +130,10 @@ namespace LdapForNet
             {
                 ThrowIfResponseError(response);
             }
-            return response.Entries;
+
+            return response.Entries
+                .Select(_ => _.ToLdapEntry())
+                .ToList();
         }
         
         public void Add(LdapEntry entry) => ThrowIfResponseError(SendRequest(new AddRequest(entry)));

--- a/LdapForNet/LdapEntry.cs
+++ b/LdapForNet/LdapEntry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 
@@ -15,7 +16,7 @@ namespace LdapForNet
     public class DirectoryEntry
     {
         public string Dn { get; set; }
-        public List<DirectoryAttribute> Attributes { get; set; }
+        public SearchResultAttributeCollection Attributes { get; set; }
 
         public LdapEntry ToLdapEntry()
         {
@@ -101,6 +102,18 @@ namespace LdapForNet
             {
                 throw new NotSupportedException($"Not supported type. Type of values is {_values.First().GetType()}");
             }
+        }
+    }
+
+    public class SearchResultAttributeCollection : KeyedCollection<string,DirectoryAttribute>
+    {
+        internal SearchResultAttributeCollection() { }
+
+        public ICollection<string> AttributeNames => Dictionary.Keys;
+        
+        protected override string GetKeyForItem(DirectoryAttribute item)
+        {
+            return item.Name;
         }
     }
 }

--- a/LdapForNet/LdapEntry.cs
+++ b/LdapForNet/LdapEntry.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace LdapForNet
 {
@@ -6,6 +10,21 @@ namespace LdapForNet
     {
         public string Dn { get; set; }
         public Dictionary<string,List<string>> Attributes { get; set; }
+    }
+
+    public class DirectoryEntry
+    {
+        public string Dn { get; set; }
+        public List<DirectoryAttribute> Attributes { get; set; }
+
+        public LdapEntry ToLdapEntry()
+        {
+            return new LdapEntry
+            {
+                Dn = Dn,
+                Attributes = Attributes.ToDictionary(_=>_.Name,_=>_.GetValues<string>().ToList())
+            };
+        }
     }
 
     public class LdapModifyEntry
@@ -19,5 +38,69 @@ namespace LdapForNet
         public string Type { get; set; }
         public List<string> Values { get; set; }
         public Native.Native.LdapModOperation LdapModOperation { get; set; } = Native.Native.LdapModOperation.LDAP_MOD_REPLACE;
+    }
+
+    public class DirectoryAttribute
+    {
+        private readonly List<object> _values = new List<object>();
+        private static readonly ASCIIEncoding Encoder = new ASCIIEncoding();//todo move to Utf8Encoding
+
+        public string Name { get; set; }
+
+        public IEnumerable<T> GetValues<T>() where T : class, IEnumerable
+        {
+            if (!_values.Any())
+            {
+                return Enumerable.Empty<T>();
+            }
+
+            var type = typeof(T);
+            var valuesType = _values.First().GetType();
+            if (type == valuesType)
+            {
+                return _values.Select(_ => _ as T);
+            }
+
+            if (type == typeof(string))
+            {
+                return _values.Select(_ => Encoder.GetString((byte[]) _))
+                    .Select(_ => _ as T);
+            }
+
+            if (type == typeof(byte[]))
+            {
+                return _values.Select(_ => Encoder.GetBytes((string) _))
+                    .Select(_ => _ as T);
+            }
+
+            throw new NotSupportedException($"Not supported type. You could specify 'string' or 'byte[]' of generic methods. Your type is {type.Name}");
+        }
+
+        internal void Add<T>(T value) where T : class, IEnumerable
+        {
+            ThrowIfWrongType<T>();
+            _values.Add(value);
+        }
+
+        internal void AddValues<T>(IEnumerable<T> values) where T : class, IEnumerable
+        {
+            ThrowIfWrongType<T>();
+            _values.AddRange(values);
+        }
+
+        private void ThrowIfWrongType<T>() where T : class, IEnumerable
+        {
+            var type = typeof(T);
+            if (type != typeof(string) && type != typeof(byte[]))
+            {
+                throw new NotSupportedException(
+                    $"Not supported type. You could specify 'string' or 'byte[]' of generic methods. Your type is {type.Name}");
+            }
+
+            if (_values.Any() && _values.First().GetType() != type)
+            {
+                throw new NotSupportedException($"Not supported type. Type of values is {_values.First().GetType()}");
+            }
+        }
     }
 }

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -54,8 +54,12 @@ namespace LdapForNet.Native
         internal abstract void ldap_msgfree(IntPtr message);
         internal abstract IntPtr ldap_first_attribute(SafeHandle ld, IntPtr entry, ref IntPtr ppBer);
         internal abstract IntPtr ldap_next_attribute(SafeHandle ld, IntPtr entry, IntPtr pBer);
-        internal abstract void ldap_value_free(IntPtr vals);
         internal abstract IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer);
+        internal abstract int ldap_count_values(IntPtr vals);
+        internal abstract void ldap_value_free(IntPtr vals);
+        internal abstract IntPtr ldap_get_values_len(SafeHandle ld, IntPtr entry, IntPtr pBer);
+        internal abstract int ldap_count_values_len(IntPtr vals);
+        internal abstract void ldap_value_free_len(IntPtr vals);
         internal abstract int ldap_add_ext(SafeHandle ld,string dn,IntPtr attrs,IntPtr serverctrls, IntPtr clientctrls,ref int msgidp );
         internal abstract int ldap_modify_ext(SafeHandle ld, string dn,IntPtr mods , IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);
         internal abstract int ldap_delete_ext(SafeHandle ld, string dn, IntPtr serverctrls, IntPtr clientctrls, ref int msgidp);

--- a/LdapForNet/Native/LdapNativeLinux.cs
+++ b/LdapForNet/Native/LdapNativeLinux.cs
@@ -260,7 +260,16 @@ namespace LdapForNet.Native
 
         internal override IntPtr ldap_next_attribute(SafeHandle ld, IntPtr entry, IntPtr pBer) => NativeMethodsLinux.ldap_next_attribute(ld, entry, pBer);
 
+        internal override int ldap_count_values(IntPtr vals) => NativeMethodsLinux.ldap_count_values(vals);
+
         internal override void ldap_value_free(IntPtr vals) => NativeMethodsLinux.ldap_value_free(vals);
+
+        internal override IntPtr ldap_get_values_len(SafeHandle ld, IntPtr entry, IntPtr pBer) =>
+            NativeMethodsLinux.ldap_get_values_len(ld, entry, pBer);
+
+        internal override int ldap_count_values_len(IntPtr vals)=> NativeMethodsLinux.ldap_count_values_len(vals);
+
+        internal override void ldap_value_free_len(IntPtr vals) => NativeMethodsLinux.ldap_value_free_len(vals);
 
         internal override IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer) => NativeMethodsLinux.ldap_get_values(ld, entry, pBer);
 

--- a/LdapForNet/Native/LdapNativeOsx.cs
+++ b/LdapForNet/Native/LdapNativeOsx.cs
@@ -260,7 +260,14 @@ namespace LdapForNet.Native
 
         internal override IntPtr ldap_next_attribute(SafeHandle ld, IntPtr entry, IntPtr pBer) => NativeMethodsOsx.ldap_next_attribute(ld, entry, pBer);
 
+        internal override int ldap_count_values(IntPtr vals) => NativeMethodsOsx.ldap_count_values(vals);
         internal override void ldap_value_free(IntPtr vals) => NativeMethodsOsx.ldap_value_free(vals);
+        internal override IntPtr ldap_get_values_len(SafeHandle ld, IntPtr entry, IntPtr pBer) =>
+            NativeMethodsOsx.ldap_get_values_len(ld, entry, pBer);
+
+        internal override int ldap_count_values_len(IntPtr vals) => NativeMethodsOsx.ldap_count_values_len(vals);
+
+        internal override void ldap_value_free_len(IntPtr vals) => NativeMethodsOsx.ldap_value_free_len(vals);
 
         internal override IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer) => NativeMethodsOsx.ldap_get_values(ld, entry, pBer);
 

--- a/LdapForNet/Native/LdapNativeWindows.cs
+++ b/LdapForNet/Native/LdapNativeWindows.cs
@@ -144,7 +144,15 @@ namespace LdapForNet.Native
 
         internal override IntPtr ldap_next_attribute(SafeHandle ld, IntPtr entry, IntPtr pBer) => NativeMethodsWindows.ldap_next_attribute(ld, entry, pBer);
 
+        internal override int ldap_count_values(IntPtr vals) => NativeMethodsWindows.ldap_count_values(vals);
+
         internal override void ldap_value_free(IntPtr vals) => NativeMethodsWindows.ldap_value_free(vals);
+        internal override IntPtr ldap_get_values_len(SafeHandle ld, IntPtr entry, IntPtr pBer) =>
+            NativeMethodsWindows.ldap_get_values_len(ld, entry, pBer);
+
+        internal override int ldap_count_values_len(IntPtr vals) => NativeMethodsWindows.ldap_count_values_len(vals);
+
+        internal override void ldap_value_free_len(IntPtr vals) => NativeMethodsWindows.ldap_value_free_len(vals);
 
         internal override IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer) => NativeMethodsWindows.ldap_get_values(ld, entry, pBer);
 

--- a/LdapForNet/Native/Native.LDAPMod.cs
+++ b/LdapForNet/Native/Native.LDAPMod.cs
@@ -70,10 +70,10 @@ namespace LdapForNet.Native
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-        public struct berval
+        public class berval
         {
-            public int bv_len;
-            public IntPtr bv_val;
+            public int bv_len = 0;
+            public IntPtr bv_val = IntPtr.Zero;
         }
     }
 }

--- a/LdapForNet/Native/NativeMethodsLinux.cs
+++ b/LdapForNet/Native/NativeMethodsLinux.cs
@@ -176,7 +176,16 @@ namespace LdapForNet.Native
         
         [DllImport(LIB_LDAP_PATH)]
         internal static extern IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer);
-        
+
+        [DllImport(LIB_LDAP_PATH)]
+        internal static extern IntPtr ldap_get_values_len(SafeHandle ld, IntPtr entry, IntPtr pBer);
+
+        [DllImport(LIB_LDAP_PATH)]
+        internal static extern void ldap_value_free_len(IntPtr vals);
+
+        [DllImport(LIB_LDAP_PATH)]
+        internal static extern int ldap_count_values_len(IntPtr vals);
+
         /// <summary>
         /// ldap_add_ext <a href="https://linux.die.net/man/3/ldap_add">Documentation</a>
         /// </summary>

--- a/LdapForNet/Native/NativeMethodsOsx.cs
+++ b/LdapForNet/Native/NativeMethodsOsx.cs
@@ -177,7 +177,16 @@ namespace LdapForNet.Native
         
         [DllImport(LIB_LDAP_PATH)]
         internal static extern IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer);
-        
+
+        [DllImport(LIB_LDAP_PATH)]
+        internal static extern IntPtr ldap_get_values_len(SafeHandle ld, IntPtr entry, IntPtr pBer);
+
+        [DllImport(LIB_LDAP_PATH)]
+        internal static extern void ldap_value_free_len(IntPtr vals);
+
+        [DllImport(LIB_LDAP_PATH)]
+        internal static extern int ldap_count_values_len(IntPtr vals);
+
         /// <summary>
         /// ldap_add_ext <a href="https://linux.die.net/man/3/ldap_add">Documentation</a>
         /// </summary>

--- a/LdapForNet/Native/NativeMethodsWindows.cs
+++ b/LdapForNet/Native/NativeMethodsWindows.cs
@@ -195,7 +195,16 @@ namespace LdapForNet.Native
         
         [DllImport(LIB_LDAP_PATH)]
         internal static extern IntPtr ldap_get_values(SafeHandle ld, IntPtr entry, IntPtr pBer);
-        
+
+        [DllImport(LIB_LDAP_PATH, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr ldap_get_values_len(SafeHandle ld, IntPtr entry, IntPtr pBer);
+
+        [DllImport(LIB_LDAP_PATH, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void ldap_value_free_len(IntPtr vals);
+
+        [DllImport(LIB_LDAP_PATH, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int ldap_count_values_len(IntPtr vals);
+
         /// <summary>
         /// ldap_add_ext <a href="https://linux.die.net/man/3/ldap_add">Documentation</a>
         /// </summary>

--- a/LdapForNet/RequestHandlers/SearchRequestHandler.cs
+++ b/LdapForNet/RequestHandlers/SearchRequestHandler.cs
@@ -63,9 +63,9 @@ namespace LdapForNet.RequestHandlers
             }
         }
         
-        private List<DirectoryAttribute> GetLdapAttributes(SafeHandle ld, IntPtr entry, ref IntPtr ber)
+        private SearchResultAttributeCollection GetLdapAttributes(SafeHandle ld, IntPtr entry, ref IntPtr ber)
         {
-            var attributes = new List<DirectoryAttribute>();
+            var attributes = new SearchResultAttributeCollection();
             for (var attr = Native.ldap_first_attribute(ld, entry, ref ber);
                 attr != IntPtr.Zero;
                 attr = Native.ldap_next_attribute(ld, entry, ber))

--- a/LdapForNet/Utils/MarshalUtils.cs
+++ b/LdapForNet/Utils/MarshalUtils.cs
@@ -10,22 +10,67 @@ namespace LdapForNet.Utils
         
         internal static List<string> PtrToStringArray(IntPtr ptr)
         {
-            var offset = 0;
+            var count = 0;
             var result = new List<string>();
-            while (true)
+            if (ptr != IntPtr.Zero)
             {
-                var el = new IntPtr(ptr.ToInt64() + offset);
-                var s = Marshal.PtrToStructure<IntPtr>(el);
-                if (s == IntPtr.Zero)
+                var tempPtr = Marshal.ReadIntPtr(ptr, IntPtr.Size * count);
+                while (tempPtr != IntPtr.Zero)
                 {
-                    break;
+                    result.Add(Marshal.PtrToStringAnsi(tempPtr));
+                    count++;
+                    tempPtr = Marshal.ReadIntPtr(ptr, IntPtr.Size * count);
                 }
-                result.Add(Marshal.PtrToStringAnsi(s));
-                offset += IntPtr.Size;
             }
             return result;
         }
-        
+
+        internal static List<byte[]> BerValArrayToByteArrays(IntPtr ptr)
+        {
+            var result = new List<byte[]>();
+            if (ptr != IntPtr.Zero)
+            {
+                var count = 0;
+                var tempPtr = Marshal.ReadIntPtr(ptr, IntPtr.Size * count);
+                while (tempPtr != IntPtr.Zero)
+                {
+                    var bervalue = new Native.Native.berval();
+                    Marshal.PtrToStructure(tempPtr, bervalue);
+                    if (bervalue.bv_len > 0 && bervalue.bv_val != IntPtr.Zero)
+                    {
+                        var byteArray = new byte[bervalue.bv_len];
+                        Marshal.Copy(bervalue.bv_val, byteArray, 0, bervalue.bv_len);
+                        result.Add(byteArray);
+                    }
+                    count++;
+                    tempPtr = Marshal.ReadIntPtr(ptr, IntPtr.Size * count);
+                }
+            }
+
+            return result;
+        }
+
+        internal static void ByteArraysToBerValueArray(byte[][] sourceData, IntPtr ptr)
+        {
+            var sourceDataPtrs = sourceData.Select(_ => Marshal.AllocCoTaskMem(_.Length + 1)).ToArray();
+            for (var i = 0; i < sourceData.Length; i++)
+            {
+                Marshal.Copy(sourceData[i].Union(new byte[] { 0 }).ToArray(), 0, sourceDataPtrs[i], sourceData[i].Length + 1);
+            }
+
+            for (var i = 0; i < sourceDataPtrs.Length; i++)
+            {
+                var berPtr = Marshal.AllocHGlobal(Marshal.SizeOf<Native.Native.berval>());
+                Marshal.StructureToPtr(new Native.Native.berval
+                {
+                    bv_val = sourceDataPtrs[i],
+                    bv_len = sourceData[i].Length
+                }, berPtr, true);
+                Marshal.StructureToPtr(berPtr, new IntPtr(ptr.ToInt64() + i * IntPtr.Size), true);
+            }
+            Marshal.StructureToPtr(IntPtr.Zero, new IntPtr(ptr.ToInt64() + sourceDataPtrs.Length * IntPtr.Size), true);
+        }
+
         internal static void StringArrayToPtr(IEnumerable<string> array, IntPtr ptr)
         {
             var ptrArray = array.Select(Marshal.StringToHGlobalAnsi).ToArray();


### PR DESCRIPTION
#11 
Example:
```c#
            using (var connection = new LdapConnection())
            {
...
                var response = (SearchResponse)await connection.SendRequestAsync(new SearchRequest("cn=admin,dc=example,dc=com", "(&(objectclass=top)(cn=admin))", LdapSearchScope.LDAP_SCOPE_SUBTREE), CancellationToken.None);
                var directoryAttribute = response.Entries.First().Attributes["objectSid"];
                var objectSid = directoryAttribute.GetValues<byte[]>().First();
            }
```