### PR TITLE
Fixed access modifiers in DirectoryAttribute

### DIFF
--- a/LdapForNet/LdapEntry.cs
+++ b/LdapForNet/LdapEntry.cs
@@ -99,7 +99,7 @@ namespace LdapForNet
                 $"Not supported type. You could specify 'string' or 'byte[]' of generic methods. Your type is {type.Name}");
         }
 
-        public List<object> GetRawValues() => _values;
+        internal List<object> GetRawValues() => _values;
 
         public void Add<T>(T value) where T : class, IEnumerable
         {

--- a/LdapForNet/LdapEntry.cs
+++ b/LdapForNet/LdapEntry.cs
@@ -99,15 +99,15 @@ namespace LdapForNet
                 $"Not supported type. You could specify 'string' or 'byte[]' of generic methods. Your type is {type.Name}");
         }
 
-        internal List<object> GetRawValues() => _values;
+        public List<object> GetRawValues() => _values;
 
-        internal void Add<T>(T value) where T : class, IEnumerable
+        public void Add<T>(T value) where T : class, IEnumerable
         {
             ThrowIfWrongType<T>();
             _values.Add(value);
         }
 
-        internal void AddValues<T>(IEnumerable<T> values) where T : class, IEnumerable
+        public void AddValues<T>(IEnumerable<T> values) where T : class, IEnumerable
         {
             ThrowIfWrongType<T>();
             _values.AddRange(values);


### PR DESCRIPTION
I just updated to 2.4.0 and tried to follow the [Reset Password](https://github.com/flamencist/ldap4net#reset-password) example. `attribute.Add` was not found so I went digging in the code and noticed these methods were marked as internal. (Add, AddValues, GetRawValues)