### PR TITLE
Expose ResultCode on LdapException and allow for AD password change.

### DIFF
--- a/LdapForNet/LdapEntry.cs
+++ b/LdapForNet/LdapEntry.cs
@@ -230,18 +230,8 @@ namespace LdapForNet
         }
     }
 
-    public class ModifyAttributeCollection : KeyedCollection<string, DirectoryModificationAttribute>
+    public class ModifyAttributeCollection : List<DirectoryModificationAttribute>
     {
-        internal ModifyAttributeCollection()
-            : base(StringComparer.OrdinalIgnoreCase)
-        {
-        }
-
-        public ICollection<string> AttributeNames => Dictionary.Keys;
-
-        protected override string GetKeyForItem(DirectoryModificationAttribute item)
-        {
-            return item.Name;
-        }
+       
     }
 }

--- a/LdapForNet/LdapException.cs
+++ b/LdapForNet/LdapException.cs
@@ -5,22 +5,27 @@ namespace LdapForNet
     [Serializable]
     public class LdapException : Exception
     {
+        public Native.Native.ResultCode?  ResultCode { get; }
+
         public LdapException(string message) : base(message)
         {
         }
 
-        public LdapException(string message, int res) : base($"{message} . Result: {res}")
+        public LdapException(string message, int res) : base($"{message}. Result: {res}")
         {
+            ResultCode =(Native.Native.ResultCode)res;
         }
 
         public LdapException(string message, string method, int res) : base(
             $"{message}. Result: {res}. Method: {method}")
         {
+            ResultCode = (Native.Native.ResultCode)res;
         }
 
         public LdapException(string message, string method, int res, string details) : base(
             $"{message}. Result: {res}. Method: {method}. Details: {details}")
         {
+            ResultCode = (Native.Native.ResultCode)res;
         }
     }
 

--- a/LdapForNet/Native/Native.LdapResultCode.cs
+++ b/LdapForNet/Native/Native.LdapResultCode.cs
@@ -34,6 +34,7 @@ namespace LdapForNet.Native
             InvalidDNSyntax = 34,
             AliasDereferencingProblem = 36,
             InappropriateAuthentication = 48,
+            InvalidCredentials = 49,
             InsufficientAccessRights = 50,
             Busy = 51,
             Unavailable = 52,


### PR DESCRIPTION

- Expose ResultCode on LdapException
- Add InvalidCredentials to the LdapResultCode enum
- Modify ModifyAttributeCollection so that it allows for multiple operations on the same attribute in the same request in order to be able to do a password update in Active Directory  as opposed to an administrative reset (https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6e803168-f140-4d23-b2d3-c3a8ab5917d2).



```
var oldPasswordAttribute = new DirectoryModificationAttribute
{
    Name = "unicodePwd",
    LdapModOperation = Native.LdapModOperation.LDAP_MOD_DELETE
};

oldPasswordAttribute.Add(Encoding.Unicode.GetBytes($"\"{oldPassword}\""));

var newPasswordAttribute = new DirectoryModificationAttribute
{
    Name = "unicodePwd",
    LdapModOperation = Native.LdapModOperation.LDAP_MOD_ADD
};

newPasswordAttribute.Add(Encoding.Unicode.GetBytes($"\"{newPassword}\""));

var response = await _ldapConnection.Value.SendRequestAsync(new ModifyRequest(userDistinguishedName, oldPasswordAttribute, newPasswordAttribute));
```