### PR TITLE
Allow password Change flow in Active Directory

### DIFF
--- a/LdapForNet.Tests/LdapConnectionTests.cs
+++ b/LdapForNet.Tests/LdapConnectionTests.cs
@@ -257,7 +257,7 @@ namespace LdapForNetTests
                     "(&(objectclass=top)(cn=admin))", LdapSearchScope.LDAP_SCOPE_SUBTREE, "cn", "objectClass"));
                 var entries = response.Entries;
                 Assert.Single(entries);
-                Assert.Equal(2, entries[0].Attributes.AttributeNames.Count);
+                Assert.Equal(2, entries[0].Attributes.AttributeNames.Count());
                 Assert.Equal(Config.LdapUserDn, entries[0].Dn);
                 Assert.Equal("admin", entries[0].Attributes["cn"].GetValues<string>().First());
                 Assert.True(entries[0].Attributes["objectClass"].GetValues<string>().Any());

--- a/LdapForNet/LdapEntry.cs
+++ b/LdapForNet/LdapEntry.cs
@@ -42,9 +42,9 @@ namespace LdapForNet
                 Attributes = Attributes.ToDictionary(_ => _.Name, _ => _.GetValues<string>().ToList())
             };
         }
-        
-        public DirectoryAttribute GetAttribute(string attribute) 
-            => this.Attributes.Contains(attribute) ? this.Attributes[attribute] : null;
+
+        public DirectoryAttribute GetAttribute(string attribute)
+            => this.Attributes.FirstOrDefault(x => String.Equals(x.Name, attribute, StringComparison.OrdinalIgnoreCase));
 
         private static Guid? GetGuid(byte[] bytes) 
             => bytes != null && bytes.Length == 16 ? (Guid?) new Guid(bytes) : null;
@@ -215,23 +215,72 @@ namespace LdapForNet
             Native.Native.LdapModOperation.LDAP_MOD_REPLACE;
     }
 
-    public class SearchResultAttributeCollection : KeyedCollection<string, DirectoryAttribute>
+    public abstract class DirectoryAttributeCollectionBase<T> : List<T>
+        where T : DirectoryAttribute
     {
-        internal SearchResultAttributeCollection()
-            : base(StringComparer.OrdinalIgnoreCase)
+        public IEnumerable<string> AttributeNames =>
+            this.Select(x => x.Name);
+        
+        public bool Contains(string attribute) =>
+            this.Any(x => String.Equals(x.Name, attribute, StringComparison.OrdinalIgnoreCase));
+
+        public DirectoryAttribute this[string attribute]
         {
+            get
+            {
+                var item = this.FirstOrDefault(x => String.Equals(x.Name, attribute, StringComparison.OrdinalIgnoreCase));
+
+                if (item == null)
+                {
+                    throw new KeyNotFoundException();
+                }
+
+                return item;
+            }
         }
 
-        public ICollection<string> AttributeNames => Dictionary.Keys;
-
-        protected override string GetKeyForItem(DirectoryAttribute item)
+        public bool TryGetValue(string attribute, out DirectoryAttribute item)
         {
-            return item.Name;
+            item = this.FirstOrDefault(x => String.Equals(x.Name, attribute, StringComparison.OrdinalIgnoreCase));
+
+            if (item == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool Remove(string attribute)
+        {
+            var found = false;
+
+            for (int i = 0; i < Count; i++)
+            {
+                if (String.Equals(this[i].Name, attribute, StringComparison.OrdinalIgnoreCase))
+                {
+                    RemoveAt(i);
+                    --i;
+
+                    found = true;
+                }
+            }
+
+            return found;
         }
     }
 
-    public class ModifyAttributeCollection : List<DirectoryModificationAttribute>
+    public class SearchResultAttributeCollection : DirectoryAttributeCollectionBase<DirectoryAttribute>
     {
-       
+        internal SearchResultAttributeCollection()
+        {
+        }
+    }
+
+    public class ModifyAttributeCollection : DirectoryAttributeCollectionBase<DirectoryModificationAttribute>
+    {
+        internal ModifyAttributeCollection()
+        {
+        }
     }
 }

--- a/LdapForNet/LdapEntry.cs
+++ b/LdapForNet/LdapEntry.cs
@@ -230,18 +230,8 @@ namespace LdapForNet
         }
     }
 
-    public class ModifyAttributeCollection : KeyedCollection<string, DirectoryModificationAttribute>
+    public class ModifyAttributeCollection : List<DirectoryModificationAttribute>
     {
-        internal ModifyAttributeCollection()
-            : base(StringComparer.OrdinalIgnoreCase)
-        {
-        }
-
-        public ICollection<string> AttributeNames => Dictionary.Keys;
-
-        protected override string GetKeyForItem(DirectoryModificationAttribute item)
-        {
-            return item.Name;
-        }
+       
     }
 }

--- a/LdapForNet/LdapException.cs
+++ b/LdapForNet/LdapException.cs
@@ -5,22 +5,27 @@ namespace LdapForNet
     [Serializable]
     public class LdapException : Exception
     {
+        public Native.Native.ResultCode?  ResultCode { get; }
+
         public LdapException(string message) : base(message)
         {
         }
 
-        public LdapException(string message, int res) : base($"{message} . Result: {res}")
+        public LdapException(string message, int res) : base($"{message}. Result: {res}")
         {
+            ResultCode =(Native.Native.ResultCode)res;
         }
 
         public LdapException(string message, string method, int res) : base(
             $"{message}. Result: {res}. Method: {method}")
         {
+            ResultCode = (Native.Native.ResultCode)res;
         }
 
         public LdapException(string message, string method, int res, string details) : base(
             $"{message}. Result: {res}. Method: {method}. Details: {details}")
         {
+            ResultCode = (Native.Native.ResultCode)res;
         }
     }
 

--- a/LdapForNet/Native/Native.LdapResultCode.cs
+++ b/LdapForNet/Native/Native.LdapResultCode.cs
@@ -34,6 +34,7 @@ namespace LdapForNet.Native
             InvalidDNSyntax = 34,
             AliasDereferencingProblem = 36,
             InappropriateAuthentication = 48,
+            InvalidCredentials = 49,
             InsufficientAccessRights = 50,
             Busy = 51,
             Unavailable = 52,


### PR DESCRIPTION
Modifying the attribute collections to allow for multiple attributes with the same name to allow the Active Directory password change (See #68 )