### PR TITLE
Fix warning CS0612 in LdapForNet: Type or member is obsolete

### DIFF
--- a/LdapForNet/DirectoryRequest.cs
+++ b/LdapForNet/DirectoryRequest.cs
@@ -266,20 +266,20 @@ namespace LdapForNet
     {
         public CompareRequest(LdapEntry ldapEntry)
         {
-            if (ldapEntry.Attributes.Count != 1)
+            if (ldapEntry.DirectoryAttributes.Count != 1)
             {
                 throw new ArgumentException("Wrong number of attributes");
             }
 
-            var attribute = ldapEntry.Attributes.Single();
-            if (attribute.Value.Count != 1)
+            var attribute = ldapEntry.DirectoryAttributes.Single();
+            if (attribute.GetRawValues().Count != 1)
             {
                 throw new ArgumentException("Wrong number of attribute values");
             }
 
             DistinguishedName = ldapEntry.Dn;
-            Assertion.Name = attribute.Key;
-            Assertion.Add(attribute.Value.Single());
+            Assertion.Name = attribute.Name;
+            Assertion.Add(attribute.GetValues<string>().Single());
         }
 
         public CompareRequest(string distinguishedName, string attributeName, byte[] value)

--- a/LdapForNet/LdapSearchExtensions.cs
+++ b/LdapForNet/LdapSearchExtensions.cs
@@ -29,9 +29,14 @@ namespace LdapForNet
             }
 
             var rootDse = connection.Search(null, "(objectclass=*)", scope: LdapSearchScope.LDAP_SCOPE_BASE).First();
-            foreach (var attribute in rootDse.Attributes)
+            foreach (var attribute in rootDse.DirectoryAttributes)
             {
-                result.Attributes[attribute.Key] = attribute.Value;
+                var index = result.DirectoryAttributes.IndexOf(attribute);
+                if (index != -1)
+                {
+                    result.DirectoryAttributes.RemoveAt(index);
+                }
+                result.DirectoryAttributes.Add(attribute);
             }
 
             return result;


### PR DESCRIPTION
`LdapEntry.Attributes` is obsolete. `LdapEntry.DirectoryAttributes` should be used instead.