### PR TITLE
Add unintrusive platform detection for FreeBSD

### DIFF
--- a/LdapForNet/LdapForNet.csproj
+++ b/LdapForNet/LdapForNet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>LdapForNet</AssemblyName>
     <RootNamespace>LdapForNet</RootNamespace>
     <Version>2.7.9</Version>

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -20,6 +20,13 @@ namespace LdapForNet.Native
                 return new LdapNativeLinux();
             }
 
+#if NETCOREAPP3_1 || NETCOREAPP5_0
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                return new LdapNativeLinux();
+            }
+#endif
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 return new LdapNativeOsx();

--- a/LdapForNet/Utils/Encoder.cs
+++ b/LdapForNet/Utils/Encoder.cs
@@ -16,6 +16,13 @@ namespace LdapForNet.Utils
                 return new UnixEncoder();
             }
 
+#if NETCOREAPP3_1 || NETCOREAPP5_0
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                return new UnixEncoder();
+            }
+#endif
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 return new UnixEncoder();


### PR DESCRIPTION
I am successfully using this library on FreeBSD with AD and OpenLDAP servers.
For now, I only tested Search and Bind operations.

**Continuous Integration**
CI for FreeBSD is not… supported by Travis

**Installation on FreeBSD**

Install the client package:
```
doas pkg install openldap-client
```

Verify that the package is installed:
```
% pkg info openldap-client
openldap-client-2.4.51
Name           : openldap-client
Version        : 2.4.51
Installed on   : -----------
Origin         : net/openldap24-client
Architecture   : FreeBSD:12:amd64
Prefix         : /usr/local
Categories     : databases net
Licenses       : OPENLDAP
Maintainer     : delphij@FreeBSD.org
WWW            : https://www.OpenLDAP.org/
Comment        : Open source LDAP client implementation
Options        :
        DEBUG          : off
        DOCS           : on
        FETCH          : off
        GSSAPI         : off
Shared Libs provided:
        libldap_r-2.4.so.2
        liblber-2.4.so.2
        libldap-2.4.so.2
Annotations    :
        FreeBSD_version: 1201000
        cpe            : cpe:2.3:a:openldap:openldap:2.4.51:::::freebsd12:x64
        repo_type      : binary
        repository     : FreeBSD
Flat size      : 6.03MiB
Description    :
OpenLDAP is a suite of Lightweight Directory Access Protocol (v3) servers,
clients, utilities and development tools.

This package includes the following major components:

 * -lldap - a LDAP client library
 * -llber - a lightweight BER/DER encoding/decoding library
 * LDAP tools - A collection of command line LDAP utilities
 * documentation - man pages for all components

WWW: https://www.OpenLDAP.org/
```

Create symbolic links:
```
doas ln -s /usr/local/lib/libldap-2.4.so.2.10.14 /usr/local/lib/libldap-2.4.so.2
doas ln -s /usr/local/lib/liblber-2.4.so.2.10.14 /usr/local/lib/liblber-2.4.so.2
```