### PR TITLE
Add TLS specific TrustAllCertificates methods

### DIFF
--- a/LdapForNet/CertificateOptions.cs
+++ b/LdapForNet/CertificateOptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LdapForNet
+{
+    [Flags]
+    public enum CertificateOptions
+    {
+        SslTls = 0,
+        StartTls = 1
+    }
+}

--- a/LdapForNet/ILdapConnection.cs
+++ b/LdapForNet/ILdapConnection.cs
@@ -40,7 +40,7 @@ namespace LdapForNet
         Task<DirectoryResponse> SendRequestAsync(DirectoryRequest directoryRequest, CancellationToken token = default);
         DirectoryResponse SendRequest(DirectoryRequest directoryRequest);
         void StartTransportLayerSecurity(bool trustAll = false);
-        void TrustAllCertificates();
+        void TrustAllCertificates(CertificateOptions certificateType = CertificateOptions.SslTls);
         void SetClientCertificate(X509Certificate2 certificate);
     }
 }

--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -285,20 +285,15 @@ namespace LdapForNet
 			ThrowIfNotInitialized();
 			if (trustAll)
 			{
-				TrustAllCertificatesTls();
+				TrustAllCertificates(CertificateOptions.StartTls);
 			}
 
 			SendRequest(new TransportLayerSecurityRequest(), out _);
 		}
 
-		public void TrustAllCertificates()
+		public void TrustAllCertificates(CertificateOptions certificateType = CertificateOptions.SslTls)
 		{
-			_native.ThrowIfError(_native.TrustAllCertificates(_ld), nameof(_native.TrustAllCertificates));
-		}
-
-		public void TrustAllCertificatesTls()
-		{
-			_native.ThrowIfError(_native.TrustAllCertificatesTls(_ld), nameof(_native.TrustAllCertificatesTls));
+			_native.ThrowIfError(_native.TrustAllCertificates(_ld, certificateType), nameof(_native.TrustAllCertificates));
 		}
 
 		public void SetClientCertificate(X509Certificate2 certificate)

--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -285,7 +285,7 @@ namespace LdapForNet
 			ThrowIfNotInitialized();
 			if (trustAll)
 			{
-				TrustAllCertificates();
+				TrustAllCertificatesTls();
 			}
 
 			SendRequest(new TransportLayerSecurityRequest(), out _);
@@ -294,6 +294,11 @@ namespace LdapForNet
 		public void TrustAllCertificates()
 		{
 			_native.ThrowIfError(_native.TrustAllCertificates(_ld), nameof(_native.TrustAllCertificates));
+		}
+
+		public void TrustAllCertificatesTls()
+		{
+			_native.ThrowIfError(_native.TrustAllCertificatesTls(_ld), nameof(_native.TrustAllCertificatesTls));
 		}
 
 		public void SetClientCertificate(X509Certificate2 certificate)

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -40,8 +40,7 @@ namespace LdapForNet.Native
             throw new PlatformNotSupportedException();
         }
 
-        internal abstract int TrustAllCertificates(SafeHandle ld);
-        internal abstract int TrustAllCertificatesTls(SafeHandle ld);
+        internal abstract int TrustAllCertificates(SafeHandle ld, CertificateOptions certificateType = CertificateOptions.SslTls);
         internal abstract int SetClientCertificate(SafeHandle ld, X509Certificate2 certificate);
         internal abstract int Init(ref IntPtr ld, string url);
         internal abstract void LdapConnect(SafeHandle ld, TimeSpan connectionTimeout);

--- a/LdapForNet/Native/LdapNative.cs
+++ b/LdapForNet/Native/LdapNative.cs
@@ -41,6 +41,7 @@ namespace LdapForNet.Native
         }
 
         internal abstract int TrustAllCertificates(SafeHandle ld);
+        internal abstract int TrustAllCertificatesTls(SafeHandle ld);
         internal abstract int SetClientCertificate(SafeHandle ld, X509Certificate2 certificate);
         internal abstract int Init(ref IntPtr ld, string url);
         internal abstract void LdapConnect(SafeHandle ld, TimeSpan connectionTimeout);

--- a/LdapForNet/Native/LdapNativeLinux.cs
+++ b/LdapForNet/Native/LdapNativeLinux.cs
@@ -17,6 +17,11 @@ namespace LdapForNet.Native
                 ref value);
         }
 
+        internal override int TrustAllCertificatesTls(SafeHandle ld)
+        {
+            return TrustAllCertificates(ld);
+        }
+
         internal override int SetClientCertificate(SafeHandle ld, X509Certificate2 certificate)
         {
             const int verifyDepth = 6;

--- a/LdapForNet/Native/LdapNativeLinux.cs
+++ b/LdapForNet/Native/LdapNativeLinux.cs
@@ -10,16 +10,11 @@ namespace LdapForNet.Native
 {
     internal class LdapNativeLinux : LdapNative
     {
-        internal override int TrustAllCertificates(SafeHandle ld)
+        internal override int TrustAllCertificates(SafeHandle ld, CertificateOptions certificateType)
         {
             var value = (int) Native.LdapOption.LDAP_OPT_X_TLS_ALLOW;
             return ldap_set_option(new LdapHandle(IntPtr.Zero), (int) Native.LdapOption.LDAP_OPT_X_TLS_REQUIRE_CERT,
                 ref value);
-        }
-
-        internal override int TrustAllCertificatesTls(SafeHandle ld)
-        {
-            return TrustAllCertificates(ld);
         }
 
         internal override int SetClientCertificate(SafeHandle ld, X509Certificate2 certificate)

--- a/LdapForNet/Native/LdapNativeOsx.cs
+++ b/LdapForNet/Native/LdapNativeOsx.cs
@@ -20,6 +20,11 @@ namespace LdapForNet.Native
                 ref value);
         }
 
+        internal override int TrustAllCertificatesTls(SafeHandle ld)
+        {
+            return TrustAllCertificates(ld);
+        }
+
         internal override int SetClientCertificate(SafeHandle ld, X509Certificate2 certificate)
         {
             var certFile = Path.GetTempFileName();

--- a/LdapForNet/Native/LdapNativeOsx.cs
+++ b/LdapForNet/Native/LdapNativeOsx.cs
@@ -13,16 +13,11 @@ namespace LdapForNet.Native
     {
         private readonly IList<string> _tempFiles = new List<string>();
 
-        internal override int TrustAllCertificates(SafeHandle ld)
+        internal override int TrustAllCertificates(SafeHandle ld, CertificateOptions certificateType)
         {
             var value = (int) Native.LdapOption.LDAP_OPT_X_TLS_ALLOW;
             return ldap_set_option(new LdapHandle(IntPtr.Zero), (int) Native.LdapOption.LDAP_OPT_X_TLS_REQUIRE_CERT,
                 ref value);
-        }
-
-        internal override int TrustAllCertificatesTls(SafeHandle ld)
-        {
-            return TrustAllCertificates(ld);
         }
 
         internal override int SetClientCertificate(SafeHandle ld, X509Certificate2 certificate)

--- a/LdapForNet/Native/LdapNativeWindows.cs
+++ b/LdapForNet/Native/LdapNativeWindows.cs
@@ -17,24 +17,18 @@ namespace LdapForNet.Native
     {
         private bool _tlsStarted;
 
-        internal override int TrustAllCertificates(SafeHandle ld)
+        internal override int TrustAllCertificates(SafeHandle ld, CertificateOptions certificateType)
         {
             var sslEnabled = 0;
             ThrowIfError(ldap_get_option(ld, (int)Native.LdapOption.LDAP_OPT_SSL, ref sslEnabled),
                 nameof(ldap_get_option));
-            if (sslEnabled == 0)
+            if (sslEnabled == 0 && certificateType == CertificateOptions.SslTls)
             {
                 sslEnabled = 1;
                 ThrowIfError(ldap_set_option(ld, (int)Native.LdapOption.LDAP_OPT_SSL, ref sslEnabled),
                     nameof(ldap_set_option));
             }
 
-            return ldap_set_option(ld, (int)Native.LdapOption.LDAP_OPT_SERVER_CERTIFICATE,
-                Marshal.GetFunctionPointerForDelegate<VERIFYSERVERCERT>((connection, serverCert) => true));
-        }
-
-        internal override int TrustAllCertificatesTls(SafeHandle ld)
-        {
             return ldap_set_option(ld, (int)Native.LdapOption.LDAP_OPT_SERVER_CERTIFICATE,
                 Marshal.GetFunctionPointerForDelegate<VERIFYSERVERCERT>((connection, serverCert) => true));
         }

--- a/LdapForNet/Native/LdapNativeWindows.cs
+++ b/LdapForNet/Native/LdapNativeWindows.cs
@@ -33,6 +33,12 @@ namespace LdapForNet.Native
                 Marshal.GetFunctionPointerForDelegate<VERIFYSERVERCERT>((connection, serverCert) => true));
         }
 
+        internal override int TrustAllCertificatesTls(SafeHandle ld)
+        {
+            return ldap_set_option(ld, (int)Native.LdapOption.LDAP_OPT_SERVER_CERTIFICATE,
+                Marshal.GetFunctionPointerForDelegate<VERIFYSERVERCERT>((connection, serverCert) => true));
+        }
+
         internal override int SetClientCertificate(SafeHandle ld, X509Certificate2 certificate)
         {
             return ldap_set_option(ld, (int)Native.LdapOption.LDAP_OPT_CLIENT_CERTIFICATE,


### PR DESCRIPTION
For Linux and OSX, nothing really changed. For windows, it will now allow a trust all certificates to work without forcing it to use LDAPS. Fixes #114 