### PR TITLE
Remove library version from libldap and liblber

### DIFF
--- a/LdapForNet/Native/NativeMethodsLinux.cs
+++ b/LdapForNet/Native/NativeMethodsLinux.cs
@@ -6,8 +6,8 @@ namespace LdapForNet.Native
 {
     internal static class NativeMethodsLinux
     {
-        private const string LIB_LDAP_PATH = "ldap-2.4.so.2";
-        private const string LIB_LBER_PATH = "lber-2.4.so.2";
+        private const string LIB_LDAP_PATH = "ldap.so.2";
+        private const string LIB_LBER_PATH = "lber.so.2";
         private const string LIB_GNUTLS = "libgnutls.so.30";
 
         internal delegate int LDAP_SASL_INTERACT_PROC(IntPtr ld, uint flags, IntPtr defaults, IntPtr interact);

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Help support the project:
 
 For Linux\OSX you must ensure you have the latest OpenLDAP client libraries installed from http://www.openldap.org
 
-  
+For Linux you must also ensure that the appropriate [symlinks for `libldap.so.2` and `liblber.so.2`](linux.md) exist.
+
 It works with any LDAP protocol compatible directory server (including Microsoft Active Directory).
 
 Supported paswordless authentication (Kerberos) on all platforms (on Linux\OSX supported SASL GSSAPI (Kerberos) authentication!).

--- a/linux.md
+++ b/linux.md
@@ -1,0 +1,23 @@
+# Linux: Symlinks for `libldap.so.2` and `liblber.so.2`
+
+After installing the OpenLDAP client libraries for Linux, you must ensure that the appropriate symlinks `libldap.so.2` and `liblber.so.2` exist in your library directory, which is usually `/lib` or `/usr/lib`.
+
+They're usually created by default when installing the OpenLDAP client libraries package and refer directly or indirectly to the latest version of the corresponding library located in the same directory, for example:
+
+```sh
+root@linux ~ % ls -l /usr/lib/libldap.so.2
+lrwxrwxrwx 1 root root 10 Jul 18  2021 /usr/lib/libldap.so.2 -> libldap.so
+root@linux ~ % ls -l /usr/lib/libldap.so
+lrwxrwxrwx 1 root root 21 Jul 18  2021 /usr/lib/libldap.so -> libldap-2.4.so.2.11.7
+root@linux ~ % ls -l /usr/lib/liblber.so.2
+lrwxrwxrwx 1 root root 10 Jul 18  2021 /usr/lib/liblber.so.2 -> liblber.so
+root@linux ~ % ls -l /usr/lib/liblber.so
+lrwxrwxrwx 1 root root 21 Jul 18  2021 /usr/lib/liblber.so -> liblber-2.4.so.2.11.7
+```
+
+If these symlinks do not exist, you can create direct links to the corresponding library using the following commands:
+
+```sh
+root@linux ~ % ln -s /usr/lib/libldap-2.X.so.2.Y.Z /usr/lib/libldap.so.2
+root@linux ~ % ln -s /usr/lib/liblber-2.X.so.2.Y.Z /usr/lib/liblber.so.2
+```


### PR DESCRIPTION
Fixes #140 and #141 by not specifying a particular version of `libldap` and `liblber` in the code, but just referencing the major version of those libraries.