### PR TITLE
If request is cancelled throw OperationCancelledException

### DIFF
--- a/LdapForNet/LdapConnection.cs
+++ b/LdapForNet/LdapConnection.cs
@@ -255,10 +255,7 @@ namespace LdapForNet
 		public async Task<DirectoryResponse> SendRequestAsync(DirectoryRequest directoryRequest,
 			CancellationToken token = default)
 		{
-			if (token.IsCancellationRequested)
-			{
-				return default;
-			}
+			token.ThrowIfCancellationRequested();
 
 			ThrowIfNotBound();
 


### PR DESCRIPTION
Instead of returning null and causing NullReferenceException throw OperationCancelledException.