### PR TITLE
Optimize RootDse search and add cancellation tokens to async search extensions.

### DIFF
--- a/LdapForNet/LdapSearchExtensions.cs
+++ b/LdapForNet/LdapSearchExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using LdapForNet.Utils;
 using static LdapForNet.Native.Native;
@@ -8,40 +9,38 @@ namespace LdapForNet
 {
     public static class LdapSearchExtensions
     {
+        public static LdapEntry GetRootDse(this ILdapConnection connection)
+        {
+            return connection.Search(
+                null,
+                "(objectclass=*)",
+                new[] { "*", "+", "supportedExtension" },
+                LdapSearchScope.LDAP_SCOPE_BASE)
+                .First();
+        }
+
+        public static async Task<LdapEntry> GetRootDseAsync(this ILdapConnection connection,
+            CancellationToken token = default)
+        {
+            return (await connection.SearchAsync(
+                null,
+                "(objectclass=*)",
+                new[] { "*", "+", "supportedExtension" },
+                LdapSearchScope.LDAP_SCOPE_BASE,
+                token))
+                .First();
+        }
+
         public static IList<LdapEntry> SearchByCn(this ILdapConnection connection, string @base, string cn,
             LdapSearchScope scope = LdapSearchScope.LDAP_SCOPE_SUBTREE)
         {
             return connection.Search(@base, $"(cn={cn})", scope: scope);
         }
 
-        public static LdapEntry GetRootDse(this ILdapConnection connection)
-        {
-            var result = connection.Search(null, "(objectclass=*)",
-                    new[]
-                    {
-                        "namingContexts", "subschemaSubentry", "supportedLDAPVersion", "supportedSASLMechanisms",
-                        "supportedExtension", "supportedControl", "supportedFeatures", "vendorName", "vendorVersion"
-                    }, LdapSearchScope.LDAP_SCOPE_BASE)
-                .FirstOrDefault();
-            if (result == null)
-            {
-                return null;
-            }
-
-            var rootDse = connection.Search(null, "(objectclass=*)", scope: LdapSearchScope.LDAP_SCOPE_BASE).First();
-            foreach (var attribute in rootDse.DirectoryAttributes)
-            {
-	            result.DirectoryAttributes.Remove(attribute.Name);
-                result.DirectoryAttributes.Add(attribute);
-            }
-
-            return result;
-        }
-
         public static async Task<IList<LdapEntry>> SearchByCnAsync(this ILdapConnection connection, string @base,
-            string cn, LdapSearchScope scope = LdapSearchScope.LDAP_SCOPE_SUBTREE)
+            string cn, LdapSearchScope scope = LdapSearchScope.LDAP_SCOPE_SUBTREE, CancellationToken token = default)
         {
-            return await connection.SearchAsync(@base, $"(cn={cn})", scope: scope);
+            return await connection.SearchAsync(@base, $"(cn={cn})", scope: scope, token: token);
         }
 
         public static IList<LdapEntry> SearchByCn(this ILdapConnection connection, string cn)
@@ -49,9 +48,10 @@ namespace LdapForNet
             return connection.SearchByCn(LdapUtils.GetDnFromHostname(), cn);
         }
 
-        public static async Task<IList<LdapEntry>> SearchByCnAsync(this ILdapConnection connection, string cn)
+        public static async Task<IList<LdapEntry>> SearchByCnAsync(this ILdapConnection connection, string cn,
+            CancellationToken token = default)
         {
-            return await connection.SearchByCnAsync(LdapUtils.GetDnFromHostname(), cn);
+            return await connection.SearchByCnAsync(LdapUtils.GetDnFromHostname(), cn, token: token);
         }
 
         public static IList<LdapEntry> SearchBySid(this ILdapConnection connection, string @base, string sid,
@@ -62,10 +62,10 @@ namespace LdapForNet
         }
 
         public static async Task<IList<LdapEntry>> SearchBySidAsync(this ILdapConnection connection, string @base,
-            string sid, LdapSearchScope scope = LdapSearchScope.LDAP_SCOPE_SUBTREE)
+            string sid, LdapSearchScope scope = LdapSearchScope.LDAP_SCOPE_SUBTREE, CancellationToken token = default)
         {
             var hex = HexEscaper.Escape(LdapSidConverter.ConvertToHex(sid));
-            return await connection.SearchAsync(@base, $"(objectSID={hex})", scope: scope);
+            return await connection.SearchAsync(@base, $"(objectSID={hex})", scope: scope, token: token);
         }
 
         public static IList<LdapEntry> SearchBySid(this ILdapConnection connection, string sid)
@@ -73,9 +73,10 @@ namespace LdapForNet
             return connection.SearchBySid(LdapUtils.GetDnFromHostname(), sid);
         }
 
-        public static async Task<IList<LdapEntry>> SearchBySidAsync(this ILdapConnection connection, string sid)
+        public static async Task<IList<LdapEntry>> SearchBySidAsync(this ILdapConnection connection, string sid,
+            CancellationToken token = default)
         {
-            return await connection.SearchBySidAsync(LdapUtils.GetDnFromHostname(), sid);
+            return await connection.SearchBySidAsync(LdapUtils.GetDnFromHostname(), sid, token: token);
         }
     }
 }


### PR DESCRIPTION
Get RootDse entry with all attributes in a single request as per LDAP RFC standard and add cancellation tokens to async search extensions.